### PR TITLE
Fix autoload clashes in helpers.php

### DIFF
--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -58,15 +58,19 @@ function collect($arr = [])
     return new Collection($arr);
 }
 
-function dump($data)
-{
-    var_dump($data);
+if(!function_exists('dump')){
+    function dump($data)
+    {
+        var_dump($data);
+    }
 }
 
-function dd($data)
-{
-    dump($data);
-    die;
+if(!function_exists('dd')){
+    function dd($data)
+    {
+        dump($data);
+        die;
+    }
 }
 
 function app()


### PR DESCRIPTION
#### Fix composer autoload error `Fatal error: Cannot redeclare dd` or `Fatal error: Cannot redeclare dump`

I get the following error after I did a clean install with `composer global require hjbdev/pvm`
```
Fatal error: Cannot redeclare dump() (previously declared in C:\Users\me\AppData\Roaming\Composer\vendor\symfony\var-dumper\Resources\functions\dump.php:18) in C:\Users\me\AppData\Roaming\Composer\vendor\hjbdev\pvm\bootstrap\helpers.php on line 61
```
I have other globally installed packages too in this case symfony's helpers are clashing with pvm helpers this fix should resolve the problem