### PR TITLE
Fixing version minor patch conditional

### DIFF
--- a/app/Commands/UseCommand.php
+++ b/app/Commands/UseCommand.php
@@ -47,8 +47,8 @@ class UseCommand extends Command
         }
 
         $versions = $versions->where('major_version', $major);
-        if($minor) $versions = $versions->where('minor_version', $minor);
-        if($patch) $versions = $versions->where('patch_version', $patch);
+        if($minor !== null) $versions = $versions->where('minor_version', $minor);
+        if($patch !== null) $versions = $versions->where('patch_version', $patch);
 
 
         if($versions->count() > 1) {


### PR DESCRIPTION
 **Fixing version minor patch conditional issues.**

 There will be issues with the condition when it comes to version 7.0.

```bash
PS C:\wampserver64\www> pvm list
📜 Available PHP Versions

    7.0.33
    7.1.33
    7.4.33
    8.0.26
    8.1.13
    8.2.0
    7.2.34
PS C:\wampserver64\www> pvm use 7.0
You have more than 1 version of PHP 7.0 installed. Please be more specific
PS C:\wampserver64\www>
```

```php
$versions = $versions->where('major_version', $major);
if($minor) $versions = $versions->where('minor_version', $minor); <-- "0" = false
if($patch) $versions = $versions->where('patch_version', $patch);
```