### PR TITLE
Move the check for the nts option above where the threadSafeString is…

### DIFF
--- a/commands/install.go
+++ b/commands/install.go
@@ -29,17 +29,17 @@ func Install(args []string) {
 	}
 
 	desireThreadSafe := true
+	if len(args) > 2 {
+		if args[2] == "nts" {
+			desireThreadSafe = false
+		}
+	}
+
 	var threadSafeString string
 	if desireThreadSafe {
 		threadSafeString = "thread safe"
 	} else {
 		threadSafeString = "non-thread safe"
-	}
-
-	if len(args) > 2 {
-		if args[2] == "nts" {
-			desireThreadSafe = false
-		}
 	}
 
 	if desireThreadSafe {


### PR DESCRIPTION
When wanting to install the non thread safe version of PHP, the output of the console contained conflicting information:

![image](https://github.com/hjbdev/pvm/assets/16978481/7e9b25f5-99ce-46d0-9f37-15a89a9681b3)

This happened because the string that contained the message part "thread safe" or  "non-thread safe" was being generated before we actually checked for the nts flag. This PR fixes that:

![image](https://github.com/hjbdev/pvm/assets/16978481/e1e5eded-60ca-403c-b7af-a79c9fa5bc1a)
