### PR TITLE
Create link to ext directory inside selected PHP version on use

### DIFF
--- a/commands/use.go
+++ b/commands/use.go
@@ -6,6 +6,7 @@ import (
 	"hjbdev/pvm/theme"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -150,6 +151,32 @@ func Use(args []string) {
 	if err != nil {
 		log.Fatalln(err)
 	}
+
+	// create directory link to ext directory
+	extensionDirPath := filepath.Join(versionFolderPath, "ext")
+	extensionLinkPath := filepath.Join(binPath, "ext")
+
+	// delete the old link first if it exists
+	if _, err := os.Stat(binPath); err == nil {
+		cmd := exec.Command("cmd", "/C", "rmdir", extensionLinkPath)
+		_, err := cmd.Output()
+		if err != nil {
+			log.Fatalln("Error deleting ext directory directory link:", err)
+			return
+		}
+	}
+
+	// create directory link - uses cmd since using os.Symlink did require extra permissions
+	cmd := exec.Command("cmd", "/C", "mklink", "/J", extensionLinkPath, extensionDirPath)
+
+	output, err := cmd.Output()
+	if err != nil {
+		log.Fatalln("Error creating ext directory symlink:", err)
+		return
+	} else {
+		theme.Info(string(output))
+	}
+	// end of ext directory link creation
 
 	var threadSafeString string
 	if threadSafe {

--- a/commands/use.go
+++ b/commands/use.go
@@ -45,8 +45,9 @@ func Use(args []string) {
 	}
 
 	// check if .pvm/bin folder exists
-	if _, err := os.Stat(filepath.Join(homeDir, ".pvm", "bin")); os.IsNotExist(err) {
-		os.Mkdir(filepath.Join(homeDir, ".pvm", "bin"), 0755)
+	binPath := filepath.Join(homeDir, ".pvm", "bin")
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		os.Mkdir(binPath, 0755)
 	}
 
 	// get all folders in .pvm/versions
@@ -113,18 +114,19 @@ func Use(args []string) {
 	}
 
 	// remove old bat script
-	batPath := filepath.Join(homeDir, ".pvm", "bin", "php.bat")
+	batPath := filepath.Join(binPath, "php.bat")
 	if _, err := os.Stat(batPath); err == nil {
 		os.Remove(batPath)
 	}
 
 	// remove the old sh script
-	shPath := filepath.Join(homeDir, ".pvm", "bin", "php")
+	shPath := filepath.Join(binPath, "php")
 	if _, err := os.Stat(shPath); err == nil {
 		os.Remove(shPath)
 	}
 
-	versionPath := filepath.Join(homeDir, ".pvm", "versions", selectedVersion.folder.Name(), "php.exe")
+	versionFolderPath := filepath.Join(homeDir, ".pvm", "versions", selectedVersion.folder.Name())
+	versionPath := filepath.Join(versionFolderPath, "php.exe")
 
 	// create bat script
 	batCommand := "@echo off \n"

--- a/commands/use.go
+++ b/commands/use.go
@@ -157,7 +157,7 @@ func Use(args []string) {
 	extensionLinkPath := filepath.Join(binPath, "ext")
 
 	// delete the old link first if it exists
-	if _, err := os.Stat(binPath); err == nil {
+	if _, err := os.Stat(extensionLinkPath); err == nil {
 		cmd := exec.Command("cmd", "/C", "rmdir", extensionLinkPath)
 		_, err := cmd.Output()
 		if err != nil {


### PR DESCRIPTION
I have the xdebug extension present in my php installations and want to use it inside PhpStorm.

Since the xdebug extension is PHP version specific I do need to select the correct dll whenever I change the PHP version. Since I do not want to do this all the time (or worse, forget to do it when switching version) I want pvm to create a directory link to the ext directory of the selected version of PHP. I can then use this directory as a path inside PhpStorm to find the xdebug.dll.

![image](https://github.com/hjbdev/pvm/assets/16978481/19660322-d791-468c-9fc8-6ab4980a56ca)

![image](https://github.com/hjbdev/pvm/assets/16978481/3391f2c5-f1ae-4dd2-9958-e9205e86ec95)
