### PR TITLE
Version rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ pvm install 8.2
 > The install command will automatically determine the newest minor/patch versions if they are not specified
 
 Will install PHP 8.2 at the latest patch.
+
+## Build
+
+To compile the program use:
+```shell
+GOOS=windows GOARCH=amd64 go build -o pvm.exe
+```

--- a/commands/help.go
+++ b/commands/help.go
@@ -7,7 +7,7 @@ import (
 
 func Help(notFoundError bool) {
 	theme.Title("pvm: PHP Version Manager")
-	theme.Info("Version 1.1")
+	theme.Info("Version 1.1.1")
 
 	if notFoundError {
 		theme.Error("Command not found")

--- a/commands/install.go
+++ b/commands/install.go
@@ -14,14 +14,6 @@ import (
 	"strings"
 )
 
-type Version struct {
-	Major      int
-	Minor      int
-	Patch      int
-	Url        string
-	ThreadSafe bool
-}
-
 func Install(args []string) {
 	if len(args) < 2 {
 		theme.Error("You must specify a version to install.")
@@ -48,7 +40,7 @@ func Install(args []string) {
 		theme.Warning("Non-thread safe version will be installed")
 	}
 
-	desiredVersionNumbers := common.GetVersion(args[1])
+	desiredVersionNumbers := common.GetVersion(args[1], desireThreadSafe, "")
 
 	if desiredVersionNumbers == (common.Version{}) {
 		theme.Error("Invalid version specified")
@@ -77,7 +69,7 @@ func Install(args []string) {
 	re := regexp.MustCompile(`<A HREF="([a-zA-Z0-9./-]+)">([a-zA-Z0-9./-]+)</A>`)
 	matches := re.FindAllStringSubmatch(sb, -1)
 
-	versions := make([]Version, 0)
+	versions := make([]common.Version, 0)
 
 	for _, match := range matches {
 		url := match[1]
@@ -118,25 +110,12 @@ func Install(args []string) {
 			continue
 		}
 
-		// regex match name
-		versionNumbers := common.GetVersion(name)
-
-		major := versionNumbers.Major
-		minor := versionNumbers.Minor
-		patch := versionNumbers.Patch
-
-		// push to versions
-		versions = append(versions, Version{
-			Major:      major,
-			Minor:      minor,
-			Patch:      patch,
-			Url:        url,
-			ThreadSafe: threadSafe,
-		})
+		// regex match name and push to versions
+		versions = append(versions, common.GetVersion(name, threadSafe, url))
 	}
 
 	// find desired version
-	var desiredVersion Version
+	var desiredVersion common.Version
 
 	if desiredMajorVersion > -1 && desiredMinorVersion > -1 && desiredPatchVersion > -1 {
 		desiredVersion = FindExactVersion(versions, desiredMajorVersion, desiredMinorVersion, desiredPatchVersion, desireThreadSafe)
@@ -150,12 +129,12 @@ func Install(args []string) {
 		desiredVersion = FindLatestMinor(versions, desiredMajorVersion, desireThreadSafe)
 	}
 
-	if desiredVersion == (Version{}) {
+	if desiredVersion == (common.Version{}) {
 		theme.Error(fmt.Sprintf("Could not find the desired version: %s %s", args[1], threadSafeString))
 		return
 	}
 
-	fmt.Printf("Installing PHP %d.%d.%d %s\n", desiredVersion.Major, desiredVersion.Minor, desiredVersion.Patch, threadSafeString)
+	fmt.Printf("Installing PHP %s\n", desiredVersion)
 
 	homeDir, err := os.UserHomeDir()
 
@@ -190,7 +169,7 @@ func Install(args []string) {
 
 	// check if zip already exists
 	if _, err := os.Stat(homeDir + "/.pvm/versions/" + zipFileName); err == nil {
-		theme.Error(fmt.Sprintf("PHP %d.%d.%d %s already exists", desiredVersion.Major, desiredVersion.Minor, desiredVersion.Patch, threadSafeString))
+		theme.Error(fmt.Sprintf("PHP %s already exists", desiredVersion))
 		return
 	}
 
@@ -222,7 +201,7 @@ func Install(args []string) {
 		log.Fatalln(err)
 	}
 
-	theme.Success(fmt.Sprintf("Finished installing PHP %d.%d.%d %s", desiredVersion.Major, desiredVersion.Minor, desiredVersion.Patch, threadSafeString))
+	theme.Success(fmt.Sprintf("Finished installing PHP %s", desiredVersion))
 }
 
 func Unzip(src, dest string) error {
@@ -289,7 +268,7 @@ func Unzip(src, dest string) error {
 	return nil
 }
 
-func FindExactVersion(versions []Version, major int, minor int, patch int, threadSafe bool) Version {
+func FindExactVersion(versions []common.Version, major int, minor int, patch int, threadSafe bool) common.Version {
 	for _, version := range versions {
 		if version.ThreadSafe != threadSafe {
 			continue
@@ -299,11 +278,11 @@ func FindExactVersion(versions []Version, major int, minor int, patch int, threa
 		}
 	}
 
-	return Version{}
+	return common.Version{}
 }
 
-func FindLatestPatch(versions []Version, major int, minor int, threadSafe bool) Version {
-	latestPatch := Version{}
+func FindLatestPatch(versions []common.Version, major int, minor int, threadSafe bool) common.Version {
+	latestPatch := common.Version{}
 
 	for _, version := range versions {
 		if version.ThreadSafe != threadSafe {
@@ -319,8 +298,8 @@ func FindLatestPatch(versions []Version, major int, minor int, threadSafe bool) 
 	return latestPatch
 }
 
-func FindLatestMinor(versions []Version, major int, threadSafe bool) Version {
-	latestMinor := Version{}
+func FindLatestMinor(versions []common.Version, major int, threadSafe bool) common.Version {
+	latestMinor := common.Version{}
 
 	for _, version := range versions {
 		if version.ThreadSafe != threadSafe {

--- a/commands/install.go
+++ b/commands/install.go
@@ -15,9 +15,9 @@ import (
 )
 
 type Version struct {
-	Major      string
-	Minor      string
-	Patch      string
+	Major      int
+	Minor      int
+	Patch      int
 	Url        string
 	ThreadSafe bool
 }
@@ -138,24 +138,24 @@ func Install(args []string) {
 	// find desired version
 	var desiredVersion Version
 
-	if desiredMajorVersion != "" && desiredMinorVersion != "" && desiredPatchVersion != "" {
+	if desiredMajorVersion > -1 && desiredMinorVersion > -1 && desiredPatchVersion > -1 {
 		desiredVersion = FindExactVersion(versions, desiredMajorVersion, desiredMinorVersion, desiredPatchVersion, desireThreadSafe)
 	}
 
-	if desiredMajorVersion != "" && desiredMinorVersion != "" && desiredPatchVersion == "" {
+	if desiredMajorVersion > -1 && desiredMinorVersion > -1 && desiredPatchVersion == -1 {
 		desiredVersion = FindLatestPatch(versions, desiredMajorVersion, desiredMinorVersion, desireThreadSafe)
 	}
 
-	if desiredMajorVersion != "" && desiredMinorVersion == "" && desiredPatchVersion == "" {
+	if desiredMajorVersion > -1 && desiredMinorVersion == -1 && desiredPatchVersion == -1 {
 		desiredVersion = FindLatestMinor(versions, desiredMajorVersion, desireThreadSafe)
 	}
 
 	if desiredVersion == (Version{}) {
-		theme.Error("Could not find the desired version: " + args[1] + " " + threadSafeString)
+		theme.Error(fmt.Sprintf("Could not find the desired version: %s %s", args[1], threadSafeString))
 		return
 	}
 
-	fmt.Println("Installing PHP " + desiredVersion.Major + "." + desiredVersion.Minor + "." + desiredVersion.Patch + " " + threadSafeString)
+	fmt.Printf("Installing PHP %d.%d.%d %s\n", desiredVersion.Major, desiredVersion.Minor, desiredVersion.Patch, threadSafeString)
 
 	homeDir, err := os.UserHomeDir()
 
@@ -190,7 +190,7 @@ func Install(args []string) {
 
 	// check if zip already exists
 	if _, err := os.Stat(homeDir + "/.pvm/versions/" + zipFileName); err == nil {
-		theme.Error("PHP " + desiredVersion.Major + "." + desiredVersion.Minor + "." + desiredVersion.Patch + " " + threadSafeString + " already exists")
+		theme.Error(fmt.Sprintf("PHP %d.%d.%d %s already exists", desiredVersion.Major, desiredVersion.Minor, desiredVersion.Patch, threadSafeString))
 		return
 	}
 
@@ -222,7 +222,7 @@ func Install(args []string) {
 		log.Fatalln(err)
 	}
 
-	theme.Success("Finished installing PHP " + desiredVersion.Major + "." + desiredVersion.Minor + "." + desiredVersion.Patch + " " + threadSafeString)
+	theme.Success(fmt.Sprintf("Finished installing PHP %d.%d.%d %s", desiredVersion.Major, desiredVersion.Minor, desiredVersion.Patch, threadSafeString))
 }
 
 func Unzip(src, dest string) error {
@@ -289,7 +289,7 @@ func Unzip(src, dest string) error {
 	return nil
 }
 
-func FindExactVersion(versions []Version, major string, minor string, patch string, threadSafe bool) Version {
+func FindExactVersion(versions []Version, major int, minor int, patch int, threadSafe bool) Version {
 	for _, version := range versions {
 		if version.ThreadSafe != threadSafe {
 			continue
@@ -302,7 +302,7 @@ func FindExactVersion(versions []Version, major string, minor string, patch stri
 	return Version{}
 }
 
-func FindLatestPatch(versions []Version, major string, minor string, threadSafe bool) Version {
+func FindLatestPatch(versions []Version, major int, minor int, threadSafe bool) Version {
 	latestPatch := Version{}
 
 	for _, version := range versions {
@@ -310,7 +310,7 @@ func FindLatestPatch(versions []Version, major string, minor string, threadSafe 
 			continue
 		}
 		if version.Major == major && version.Minor == minor {
-			if latestPatch.Patch == "" || version.Patch > latestPatch.Patch {
+			if latestPatch.Patch == -1 || version.Patch > latestPatch.Patch {
 				latestPatch = version
 			}
 		}
@@ -319,7 +319,7 @@ func FindLatestPatch(versions []Version, major string, minor string, threadSafe 
 	return latestPatch
 }
 
-func FindLatestMinor(versions []Version, major string, threadSafe bool) Version {
+func FindLatestMinor(versions []Version, major int, threadSafe bool) Version {
 	latestMinor := Version{}
 
 	for _, version := range versions {
@@ -327,8 +327,8 @@ func FindLatestMinor(versions []Version, major string, threadSafe bool) Version 
 			continue
 		}
 		if version.Major == major {
-			if latestMinor.Minor == "" || version.Minor > latestMinor.Minor {
-				if latestMinor.Patch == "" || version.Patch > latestMinor.Patch {
+			if latestMinor.Minor == -1 || version.Minor > latestMinor.Minor {
+				if latestMinor.Patch == -1 || version.Patch > latestMinor.Patch {
 					latestMinor = version
 				}
 			}

--- a/commands/list.go
+++ b/commands/list.go
@@ -4,7 +4,6 @@ import (
 	"hjbdev/pvm/theme"
 	"log"
 	"os"
-
 	"github.com/fatih/color"
 )
 

--- a/commands/use.go
+++ b/commands/use.go
@@ -69,7 +69,7 @@ func Use(args []string) {
 	// check if version exists
 	var selectedVersion *versionMeta
 	for _, version := range availableVersions {
-		if version.number.Major+"."+version.number.Minor+"."+version.number.Patch == args[0] {
+		if fmt.Sprintf("%d.%d.%d", version.number.Major, version.number.Minor, version.number.Patch) == args[0] {
 			if threadSafe && !strings.Contains(version.folder.Name(), "nts") {
 				selectedVersion = &versionMeta{
 					number: version.number,
@@ -90,7 +90,7 @@ func Use(args []string) {
 		availableVersions = sortVersions(availableVersions)
 
 		for _, version := range availableVersions {
-			if version.number.Major+"."+version.number.Minor == args[0] {
+			if fmt.Sprintf("%d.%d", version.number.Major, version.number.Minor) == args[0] {
 				if threadSafe && !strings.Contains(version.folder.Name(), "nts") {
 					selectedVersion = &versionMeta{
 						number: version.number,

--- a/commands/use.go
+++ b/commands/use.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -57,61 +56,32 @@ func Use(args []string) {
 		log.Fatalln(err)
 	}
 
-	// transform to easily sortable slice
-	var availableVersions []versionMeta
-	for i, version := range versions {
-		availableVersions = append(availableVersions, versionMeta{
-			number: common.GetVersion(version.Name()),
-			folder: versions[i],
-		})
-	}
-
-	// check if version exists
 	var selectedVersion *versionMeta
-	for _, version := range availableVersions {
-		if fmt.Sprintf("%d.%d.%d", version.number.Major, version.number.Minor, version.number.Patch) == args[0] {
-			if threadSafe && !strings.Contains(version.folder.Name(), "nts") {
-				selectedVersion = &versionMeta{
-					number: version.number,
-					folder: version.folder,
-				}
-			} else if !threadSafe && strings.Contains(version.folder.Name(), "nts") {
-				selectedVersion = &versionMeta{
-					number: version.number,
-					folder: version.folder,
-				}
+	// loop over all found installed versions
+	for i, version := range versions {
+		safe := true
+		if strings.Contains(version.Name(), "nts") || strings.Contains(version.Name(), "NTS") {
+			safe = false
+		}
+		foundVersion := common.GetVersion(version.Name(), safe, "")
+		if threadSafe == foundVersion.ThreadSafe && strings.HasPrefix(foundVersion.String(), args[0]) {
+			selectedVersion = &versionMeta{
+				number: foundVersion,
+				folder: versions[i],
 			}
 		}
 	}
 
-	// if patch version is not specified, use the newest matching major.minor
 	if selectedVersion == nil {
-		// Sort by newest patch first
-		availableVersions = sortVersions(availableVersions)
+		theme.Error("The specified version is not installed.")
+		return
+	}
 
-		for _, version := range availableVersions {
-			if fmt.Sprintf("%d.%d", version.number.Major, version.number.Minor) == args[0] {
-				if threadSafe && !strings.Contains(version.folder.Name(), "nts") {
-					selectedVersion = &versionMeta{
-						number: version.number,
-						folder: version.folder,
-					}
-				} else if !threadSafe && strings.Contains(version.folder.Name(), "nts") {
-					selectedVersion = &versionMeta{
-						number: version.number,
-						folder: version.folder,
-					}
-				}
-				break
-			}
-		}
-
-		if selectedVersion == nil {
-			theme.Error("The specified version is not installed.")
-			return
-		} else {
-			theme.Warning(fmt.Sprintf("No patch version specified, assumed newest patch version %s.", selectedVersion.number.String()))
-		}
+	requestedVersion := common.GetVersion(args[0], threadSafe, "")
+	if requestedVersion.Minor == -1 {
+		theme.Warning(fmt.Sprintf("No minor version specified, assumed newest minor version %s.", selectedVersion.number.String()))
+	} else if requestedVersion.Patch == -1 {
+		theme.Warning(fmt.Sprintf("No patch version specified, assumed newest patch version %s.", selectedVersion.number.String()))
 	}
 
 	// remove old php bat script
@@ -214,28 +184,7 @@ func Use(args []string) {
 	}
 	// end of ext directory link creation
 
-	var threadSafeString string
-	if threadSafe {
-		threadSafeString = "thread safe"
-	} else {
-		threadSafeString = "non-thread safe"
-	}
-
-	theme.Success("Using PHP " + selectedVersion.number.String() + " " + threadSafeString)
-}
-
-func sortVersions(in []versionMeta) []versionMeta {
-	sort.Slice(in, func(i, j int) bool {
-		if in[i].number.Major != in[j].number.Major {
-			return in[i].number.Major > in[j].number.Major
-		}
-		if in[i].number.Minor != in[j].number.Minor {
-			return in[i].number.Minor > in[j].number.Minor
-		}
-		return in[i].number.Patch > in[j].number.Patch
-	})
-
-	return in
+	theme.Success(fmt.Sprintf("Using PHP %s", selectedVersion.number))
 }
 
 type versionMeta struct {

--- a/commands/use_test.go
+++ b/commands/use_test.go
@@ -1,11 +1,8 @@
 package commands
 
 import (
-	"github.com/stretchr/testify/assert"
-	"hjbdev/pvm/common"
 	"io/fs"
 	"os"
-	"testing"
 )
 
 // mock os.DirEntry for test
@@ -25,110 +22,4 @@ func (f fakeDirEntry) Type() os.FileMode {
 
 func (f fakeDirEntry) Info() (os.FileInfo, error) {
 	return nil, nil
-}
-
-func Test_sortVersions_sortsVersionsDescending(t *testing.T) {
-	input := []versionMeta{
-		{
-			number: common.Version{
-				Major: 7,
-				Minor: 4,
-				Patch: 1,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 7,
-				Minor: 4,
-				Patch: 2,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 8,
-				Minor: 3,
-				Patch: 0,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 8,
-				Minor: 3,
-				Patch: 1,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 8,
-				Minor: 2,
-				Patch: 0,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 8,
-				Minor: 2,
-				Patch: 5,
-			},
-			folder: fakeDirEntry{},
-		},
-	}
-
-	output := sortVersions(input)
-
-	assert.Equal(t, []versionMeta{
-		{
-			number: common.Version{
-				Major: 8,
-				Minor: 3,
-				Patch: 1,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 8,
-				Minor: 3,
-				Patch: 0,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 8,
-				Minor: 2,
-				Patch: 5,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 8,
-				Minor: 2,
-				Patch: 0,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 7,
-				Minor: 4,
-				Patch: 2,
-			},
-			folder: fakeDirEntry{},
-		},
-		{
-			number: common.Version{
-				Major: 7,
-				Minor: 4,
-				Patch: 1,
-			},
-			folder: fakeDirEntry{},
-		},
-	}, output)
 }

--- a/commands/use_test.go
+++ b/commands/use_test.go
@@ -31,49 +31,49 @@ func Test_sortVersions_sortsVersionsDescending(t *testing.T) {
 	input := []versionMeta{
 		{
 			number: common.Version{
-				Major: "7",
-				Minor: "4",
-				Patch: "1",
+				Major: 7,
+				Minor: 4,
+				Patch: 1,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "7",
-				Minor: "4",
-				Patch: "2",
+				Major: 7,
+				Minor: 4,
+				Patch: 2,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "8",
-				Minor: "3",
-				Patch: "0",
+				Major: 8,
+				Minor: 3,
+				Patch: 0,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "8",
-				Minor: "3",
-				Patch: "1",
+				Major: 8,
+				Minor: 3,
+				Patch: 1,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "8",
-				Minor: "2",
-				Patch: "0",
+				Major: 8,
+				Minor: 2,
+				Patch: 0,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "8",
-				Minor: "2",
-				Patch: "5",
+				Major: 8,
+				Minor: 2,
+				Patch: 5,
 			},
 			folder: fakeDirEntry{},
 		},
@@ -84,49 +84,49 @@ func Test_sortVersions_sortsVersionsDescending(t *testing.T) {
 	assert.Equal(t, []versionMeta{
 		{
 			number: common.Version{
-				Major: "8",
-				Minor: "3",
-				Patch: "1",
+				Major: 8,
+				Minor: 3,
+				Patch: 1,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "8",
-				Minor: "3",
-				Patch: "0",
+				Major: 8,
+				Minor: 3,
+				Patch: 0,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "8",
-				Minor: "2",
-				Patch: "5",
+				Major: 8,
+				Minor: 2,
+				Patch: 5,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "8",
-				Minor: "2",
-				Patch: "0",
+				Major: 8,
+				Minor: 2,
+				Patch: 0,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "7",
-				Minor: "4",
-				Patch: "2",
+				Major: 7,
+				Minor: 4,
+				Patch: 2,
 			},
 			folder: fakeDirEntry{},
 		},
 		{
 			number: common.Version{
-				Major: "7",
-				Minor: "4",
-				Patch: "1",
+				Major: 7,
+				Minor: 4,
+				Patch: 1,
 			},
 			folder: fakeDirEntry{},
 		},

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -7,16 +7,22 @@ import (
 )
 
 type Version struct {
-	Major int
-	Minor int
-	Patch int
+	Major      int
+	Minor      int
+	Patch      int
+	Url        string
+	ThreadSafe bool
 }
 
 func (v Version) String() string {
-	return fmt.Sprintf("%s.%s.%s", v.Major, v.Minor, v.Patch)
+	semantic := fmt.Sprintf("%v.%v.%v", v.Major, v.Minor, v.Patch)
+	if v.ThreadSafe {
+		return semantic + " thread safe"
+	}
+	return semantic + " non-thread safe"
 }
 
-func GetVersion(text string) Version {
+func GetVersion(text string, safe bool, url string) Version {
 	versionRe := regexp.MustCompile(`([0-9]{1,3})(?:.([0-9]{1,3}))?(?:.([0-9]{1,3}))?`)
 	matches := versionRe.FindAllStringSubmatch(text, -1)
 	if len(matches) == 0 {
@@ -39,8 +45,10 @@ func GetVersion(text string) Version {
 	}
 
 	return Version{
-		Major: major,
-		Minor: minor,
-		Patch: patch,
+		Major:      major,
+		Minor:      minor,
+		Patch:      patch,
+		ThreadSafe: safe,
+		Url:        url,
 	}
 }

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -3,12 +3,13 @@ package common
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 )
 
 type Version struct {
-	Major string
-	Minor string
-	Patch string
+	Major int
+	Minor int
+	Patch int
 }
 
 func (v Version) String() string {
@@ -22,9 +23,24 @@ func GetVersion(text string) Version {
 		return Version{}
 	}
 
+	major, err := strconv.Atoi(matches[0][1])
+	if err != nil {
+		major = -1
+	}
+
+	minor, err := strconv.Atoi(matches[0][2])
+	if err != nil {
+		minor = -1
+	}
+
+	patch, err := strconv.Atoi(matches[0][3])
+	if err != nil {
+		patch = -1
+	}
+
 	return Version{
-		Major: matches[0][1],
-		Minor: matches[0][2],
-		Patch: matches[0][3],
+		Major: major,
+		Minor: minor,
+		Patch: patch,
 	}
 }


### PR DESCRIPTION
It all started with "FindLatestXXX" functions sorting in alphabetical order instead of numeric... and ended with a major rework!

I reworked how the struct Version is used in the program. Then I could go deeper and remove some extra loops that were unnecessary.

Now there is no need to sort versions found on disk and the FindLatestXXX functions works as expected.

I've also removed the test that was testing the version sorting.

Thank you for taking time to review it. I'm still very new to Go, I'll try to write some automated tests next time.
