### PR TITLE
(feat): toggling extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ pvm install 8.2
 
 Will install PHP 8.2 at the latest patch.
 
+```
+pvm extensions list
+```
+Will show regular and Zend extensions for the active PHP version, including whether each extension is enabled, disabled, available in `ext`, or missing from disk.
+
+```
+pvm extensions enable curl,openssl
+```
+Will enable one or more extensions that already have entries in the active version's `php.ini`.
+
+```
+pvm extensions disable xdebug
+```
+Will disable an extension or Zend extension in the active version's `php.ini`.
+
 ## Composer support
 `pvm` now installs also composer with each php version installed.
 It will install Composer latest stable release for PHP >= 7.2 and Composer latest 2.2.x LTS for PHP < 7.2.

--- a/commands/extensions.go
+++ b/commands/extensions.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"hjbdev/pvm/common"
+	"hjbdev/pvm/theme"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func Extensions(args []string) {
+	if len(args) < 2 {
+		theme.Error("You must specify an action and an extension.")
+		theme.Info("Usage: pvm extensions <enable|disable> <extension>")
+		return
+	}
+
+	// determine which version is currently selected
+	currentVersion := common.GetCurrentVersionFolder()
+
+	if currentVersion == "" {
+		theme.Error("You do not have an active PHP version.")
+		theme.Info("Select a PHP version with `pvm use <version>` first.")
+	}
+
+	command := args[0]
+	ext := args[1]
+
+	if command != "enable" && command != "disable" {
+		theme.Error("Invalid action. Must be 'enable' or 'disable'.")
+		return
+	}
+
+	homeDir, err := os.UserHomeDir()
+
+	if err != nil {
+		panic(err)
+	}
+
+	// check if the version exists
+	if _, err := os.Stat(homeDir + "/.pvm/versions/" + currentVersion); os.IsNotExist(err) {
+		theme.Error("The specified version does not exist.")
+		return
+	}
+
+	extensions := strings.Split(ext, ",")
+
+	for _, extension := range extensions {
+		handleExtension(extension, command, homeDir, currentVersion)
+	}
+}
+
+func handleExtension(ext string, command string, homeDir string, currentVersion string) {
+	ini := common.ReadPhpIni(homeDir + "/.pvm/versions/" + currentVersion + "/php.ini")
+	splitIni := regexp.MustCompile(`\r?\n`).Split(ini, -1)
+	extensionStatus, lineNumber := common.GetExtensionStatus(ini, ext)
+
+	if extensionStatus == common.ExtensionEnabled {
+		if command == "enable" {
+			theme.Success("Extension " + ext + " is already enabled.")
+		} else {
+			disabledLine := ";" + splitIni[lineNumber]
+			splitIni[lineNumber] = disabledLine
+			newIni := strings.Join(splitIni, "\n")
+			os.WriteFile(filepath.Join(homeDir, ".pvm", "versions", currentVersion, "php.ini"), []byte(newIni), 0644)
+			theme.Success("Extension " + ext + " enabled.")
+		}
+	} else if extensionStatus == common.ExtensionDisabled {
+		if command == "enable" {
+			enabledLine := strings.Replace(splitIni[lineNumber], ";", "", 1)
+			splitIni[lineNumber] = enabledLine
+			newIni := strings.Join(splitIni, "\n")
+			os.WriteFile(filepath.Join(homeDir, ".pvm", "versions", currentVersion, "php.ini"), []byte(newIni), 0644)
+			theme.Success("Extension " + ext + " enabled.")
+		} else {
+			theme.Success("Extension " + ext + " is already disabled.")
+		}
+	} else {
+		theme.Error("Extension " + ext + " not found in php.ini")
+	}
+}

--- a/commands/extensions.go
+++ b/commands/extensions.go
@@ -146,11 +146,28 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 	changed := false
 
 	for _, extension := range extensions {
-		extensionStatus, lineNumber, directiveKind := common.GetDirectiveStatus(currentIni, extension)
-		label := extensionLabel(extension, directiveKind)
+		matches := matchingDirectiveEntries(currentIni, extension)
+		if len(matches) == 0 {
+			results = append(results, extensionResult{
+				name:    extension,
+				kind:    "error",
+				message: "Extension or Zend extension " + extension + " not found in php.ini",
+			})
+			continue
+		}
 
-		switch extensionStatus {
-		case common.ExtensionEnabled:
+		directiveKind := matches[0].Kind
+		label := extensionLabel(extension, directiveKind)
+		hasEnabled := false
+		for _, match := range matches {
+			if match.Enabled {
+				hasEnabled = true
+				break
+			}
+		}
+
+		switch {
+		case hasEnabled:
 			if command == "enable" {
 				results = append(results, extensionResult{
 					name:    extension,
@@ -160,7 +177,9 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 				continue
 			}
 
-			splitIni[lineNumber] = ";" + strings.TrimPrefix(splitIni[lineNumber], ";")
+			for _, match := range matches {
+				splitIni[match.Line] = ";" + strings.TrimPrefix(splitIni[match.Line], ";")
+			}
 			currentIni = strings.Join(splitIni, separator)
 			changed = true
 			results = append(results, extensionResult{
@@ -168,7 +187,7 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 				kind:    "success",
 				message: label + " disabled.",
 			})
-		case common.ExtensionDisabled:
+		default:
 			if command == "disable" {
 				results = append(results, extensionResult{
 					name:    extension,
@@ -178,19 +197,15 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 				continue
 			}
 
-			splitIni[lineNumber] = strings.TrimPrefix(splitIni[lineNumber], ";")
+			for _, match := range matches {
+				splitIni[match.Line] = strings.TrimPrefix(splitIni[match.Line], ";")
+			}
 			currentIni = strings.Join(splitIni, separator)
 			changed = true
 			results = append(results, extensionResult{
 				name:    extension,
 				kind:    "success",
 				message: label + " enabled.",
-			})
-		default:
-			results = append(results, extensionResult{
-				name:    extension,
-				kind:    "error",
-				message: "Extension or Zend extension " + extension + " not found in php.ini",
 			})
 		}
 	}
@@ -200,6 +215,21 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 	}
 
 	return currentIni, results, true
+}
+
+func matchingDirectiveEntries(ini string, extension string) []common.PhpIniExtension {
+	normalizedExtension := common.NormalizeExtensionName(extension)
+	matches := make([]common.PhpIniExtension, 0)
+
+	for _, entry := range common.ParsePhpIniExtensions(ini) {
+		if entry.Name != normalizedExtension {
+			continue
+		}
+
+		matches = append(matches, entry)
+	}
+
+	return matches
 }
 
 func buildExtensionInventory(ini string, extensionFiles []string) extensionInventory {

--- a/commands/extensions.go
+++ b/commands/extensions.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+type extensionResult struct {
+	name    string
+	kind    string
+	message string
+}
+
 func Extensions(args []string) {
 	if len(args) < 2 {
 		theme.Error("You must specify an action and an extension.")
@@ -16,9 +22,7 @@ func Extensions(args []string) {
 		return
 	}
 
-	// determine which version is currently selected
 	currentVersion := common.GetCurrentVersionFolder()
-
 	if currentVersion == "" {
 		theme.Error("You do not have an active PHP version.")
 		theme.Info("Select a PHP version with `pvm use <version>` first.")
@@ -26,10 +30,14 @@ func Extensions(args []string) {
 	}
 
 	command := args[0]
-	ext := args[1]
-
 	if command != "enable" && command != "disable" {
 		theme.Error("Invalid action. Must be 'enable' or 'disable'.")
+		return
+	}
+
+	extensions := normalizeExtensions(args[1])
+	if len(extensions) == 0 {
+		theme.Error("You must specify at least one extension.")
 		return
 	}
 
@@ -45,52 +53,123 @@ func Extensions(args []string) {
 		return
 	}
 
-	extensions := strings.Split(ext, ",")
-
-	for _, extension := range extensions {
-		handleExtension(extension, command, homeDir, currentVersion)
-	}
-}
-
-func handleExtension(ext string, command string, homeDir string, currentVersion string) {
-	iniPath := filepath.Join(homeDir, ".pvm", "versions", currentVersion, "php.ini")
+	iniPath := filepath.Join(versionPath, "php.ini")
 	ini, err := common.ReadPhpIni(iniPath)
 	if err != nil {
 		theme.Error("Could not read php.ini for the active PHP version.")
 		return
 	}
 
-	splitIni := regexp.MustCompile(`\r?\n`).Split(ini, -1)
-	extensionStatus, lineNumber := common.GetExtensionStatus(ini, ext)
+	newIni, results, changed := applyExtensionChanges(ini, command, extensions)
+	if changed {
+		if err := os.WriteFile(iniPath, []byte(newIni), 0644); err != nil {
+			theme.Error("Could not update php.ini for the active PHP version.")
+			return
+		}
+	}
 
-	switch extensionStatus {
-	case common.ExtensionEnabled:
-		if command == "enable" {
-			theme.Success("Extension " + ext + " is already enabled.")
-		} else {
-			disabledLine := ";" + splitIni[lineNumber]
-			splitIni[lineNumber] = disabledLine
-			newIni := strings.Join(splitIni, "\n")
-			if err := os.WriteFile(iniPath, []byte(newIni), 0644); err != nil {
-				theme.Error("Could not update php.ini for the active PHP version.")
-				return
-			}
-			theme.Success("Extension " + ext + " disabled.")
+	reportExtensionResults(results)
+}
+
+func normalizeExtensions(raw string) []string {
+	parts := strings.Split(raw, ",")
+	seen := make(map[string]struct{}, len(parts))
+	extensions := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		extension := strings.TrimSpace(part)
+		if extension == "" {
+			continue
 		}
-	case common.ExtensionDisabled:
-		if command == "enable" {
-			enabledLine := strings.Replace(splitIni[lineNumber], ";", "", 1)
-			splitIni[lineNumber] = enabledLine
-			newIni := strings.Join(splitIni, "\n")
-			if err := os.WriteFile(iniPath, []byte(newIni), 0644); err != nil {
-				theme.Error("Could not update php.ini for the active PHP version.")
-				return
-			}
-			theme.Success("Extension " + ext + " enabled.")
-		} else {
-			theme.Success("Extension " + ext + " is already disabled.")
+		if _, ok := seen[extension]; ok {
+			continue
 		}
-	default:
-		theme.Error("Extension " + ext + " not found in php.ini")
+
+		seen[extension] = struct{}{}
+		extensions = append(extensions, extension)
+	}
+
+	return extensions
+}
+
+func applyExtensionChanges(ini string, command string, extensions []string) (string, []extensionResult, bool) {
+	separator := detectLineSeparator(ini)
+	splitIni := regexp.MustCompile(`\r?\n`).Split(ini, -1)
+	currentIni := ini
+	results := make([]extensionResult, 0, len(extensions))
+	changed := false
+
+	for _, extension := range extensions {
+		extensionStatus, lineNumber := common.GetExtensionStatus(currentIni, extension)
+
+		switch extensionStatus {
+		case common.ExtensionEnabled:
+			if command == "enable" {
+				results = append(results, extensionResult{
+					name:    extension,
+					kind:    "success",
+					message: "Extension " + extension + " is already enabled.",
+				})
+				continue
+			}
+
+			splitIni[lineNumber] = ";" + splitIni[lineNumber]
+			currentIni = strings.Join(splitIni, separator)
+			changed = true
+			results = append(results, extensionResult{
+				name:    extension,
+				kind:    "success",
+				message: "Extension " + extension + " disabled.",
+			})
+		case common.ExtensionDisabled:
+			if command == "disable" {
+				results = append(results, extensionResult{
+					name:    extension,
+					kind:    "success",
+					message: "Extension " + extension + " is already disabled.",
+				})
+				continue
+			}
+
+			splitIni[lineNumber] = strings.Replace(splitIni[lineNumber], ";", "", 1)
+			currentIni = strings.Join(splitIni, separator)
+			changed = true
+			results = append(results, extensionResult{
+				name:    extension,
+				kind:    "success",
+				message: "Extension " + extension + " enabled.",
+			})
+		default:
+			results = append(results, extensionResult{
+				name:    extension,
+				kind:    "error",
+				message: "Extension " + extension + " not found in php.ini",
+			})
+		}
+	}
+
+	if !changed {
+		return currentIni, results, false
+	}
+
+	return currentIni, results, true
+}
+
+func detectLineSeparator(content string) string {
+	if strings.Contains(content, "\r\n") {
+		return "\r\n"
+	}
+
+	return "\n"
+}
+
+func reportExtensionResults(results []extensionResult) {
+	for _, result := range results {
+		if result.kind == "error" {
+			theme.Error(result.message)
+			continue
+		}
+
+		theme.Success(result.message)
 	}
 }

--- a/commands/extensions.go
+++ b/commands/extensions.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
+
+	"github.com/fatih/color"
 )
 
 type extensionResult struct {
@@ -15,10 +18,16 @@ type extensionResult struct {
 	message string
 }
 
+type extensionInventory struct {
+	Enabled   []string
+	Disabled  []string
+	Available []string
+}
+
 func Extensions(args []string) {
-	if len(args) < 2 {
-		theme.Error("You must specify an action and an extension.")
-		theme.Info("Usage: pvm extensions <enable|disable> <extension>")
+	if len(args) < 1 {
+		theme.Error("You must specify an action.")
+		theme.Info("Usage: pvm extensions <list|enable|disable> [extension[,extension...]]")
 		return
 	}
 
@@ -30,14 +39,8 @@ func Extensions(args []string) {
 	}
 
 	command := args[0]
-	if command != "enable" && command != "disable" {
-		theme.Error("Invalid action. Must be 'enable' or 'disable'.")
-		return
-	}
-
-	extensions := normalizeExtensions(args[1])
-	if len(extensions) == 0 {
-		theme.Error("You must specify at least one extension.")
+	if command != "list" && command != "enable" && command != "disable" {
+		theme.Error("Invalid action. Must be 'list', 'enable' or 'disable'.")
 		return
 	}
 
@@ -60,6 +63,23 @@ func Extensions(args []string) {
 		return
 	}
 
+	if command == "list" {
+		listExtensions(versionPath, ini)
+		return
+	}
+
+	if len(args) < 2 {
+		theme.Error("You must specify at least one extension.")
+		theme.Info("Usage: pvm extensions <enable|disable> <extension[,extension...]>")
+		return
+	}
+
+	extensions := normalizeExtensions(args[1])
+	if len(extensions) == 0 {
+		theme.Error("You must specify at least one extension.")
+		return
+	}
+
 	newIni, results, changed := applyExtensionChanges(ini, command, extensions)
 	if changed {
 		if err := os.WriteFile(iniPath, []byte(newIni), 0644); err != nil {
@@ -71,13 +91,27 @@ func Extensions(args []string) {
 	reportExtensionResults(results)
 }
 
+func listExtensions(versionPath string, ini string) {
+	extensionFiles, err := readAvailableExtensionFiles(versionPath)
+	if err != nil {
+		theme.Error("Could not read the ext directory for the active PHP version.")
+		return
+	}
+
+	inventory := buildExtensionInventory(ini, extensionFiles)
+
+	reportExtensionGroup("Enabled extensions", inventory.Enabled)
+	reportExtensionGroup("Disabled extensions", inventory.Disabled)
+	reportExtensionGroup("Available extensions", inventory.Available)
+}
+
 func normalizeExtensions(raw string) []string {
 	parts := strings.Split(raw, ",")
 	seen := make(map[string]struct{}, len(parts))
 	extensions := make([]string, 0, len(parts))
 
 	for _, part := range parts {
-		extension := strings.TrimSpace(part)
+		extension := common.NormalizeExtensionName(part)
 		if extension == "" {
 			continue
 		}
@@ -113,7 +147,7 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 				continue
 			}
 
-			splitIni[lineNumber] = ";" + splitIni[lineNumber]
+			splitIni[lineNumber] = ";" + strings.TrimPrefix(splitIni[lineNumber], ";")
 			currentIni = strings.Join(splitIni, separator)
 			changed = true
 			results = append(results, extensionResult{
@@ -131,7 +165,7 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 				continue
 			}
 
-			splitIni[lineNumber] = strings.Replace(splitIni[lineNumber], ";", "", 1)
+			splitIni[lineNumber] = strings.TrimPrefix(splitIni[lineNumber], ";")
 			currentIni = strings.Join(splitIni, separator)
 			changed = true
 			results = append(results, extensionResult{
@@ -155,6 +189,89 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 	return currentIni, results, true
 }
 
+func buildExtensionInventory(ini string, extensionFiles []string) extensionInventory {
+	configured := make(map[string]common.ExtensionStatus)
+	available := make(map[string]struct{}, len(extensionFiles))
+
+	for _, entry := range common.ParsePhpIniExtensions(ini) {
+		status := common.ExtensionDisabled
+		if entry.Enabled {
+			status = common.ExtensionEnabled
+		}
+
+		if existingStatus, ok := configured[entry.Name]; ok && existingStatus == common.ExtensionEnabled {
+			continue
+		}
+
+		configured[entry.Name] = status
+	}
+
+	for _, extensionFile := range extensionFiles {
+		normalized := common.NormalizeExtensionName(extensionFile)
+		if normalized == "" {
+			continue
+		}
+
+		available[normalized] = struct{}{}
+	}
+
+	inventory := extensionInventory{
+		Enabled:   make([]string, 0),
+		Disabled:  make([]string, 0),
+		Available: make([]string, 0),
+	}
+
+	for name, status := range configured {
+		label := name
+		if _, ok := available[name]; !ok {
+			label += " (missing file)"
+		}
+
+		if status == common.ExtensionEnabled {
+			inventory.Enabled = append(inventory.Enabled, label)
+			continue
+		}
+
+		inventory.Disabled = append(inventory.Disabled, label)
+	}
+
+	for name := range available {
+		if _, ok := configured[name]; ok {
+			continue
+		}
+
+		inventory.Available = append(inventory.Available, name)
+	}
+
+	sort.Strings(inventory.Enabled)
+	sort.Strings(inventory.Disabled)
+	sort.Strings(inventory.Available)
+
+	return inventory
+}
+
+func readAvailableExtensionFiles(versionPath string) ([]string, error) {
+	extPath := filepath.Join(versionPath, "ext")
+	entries, err := os.ReadDir(extPath)
+	if err != nil {
+		return nil, err
+	}
+
+	extensionFiles := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".dll") {
+			continue
+		}
+
+		extensionFiles = append(extensionFiles, entry.Name())
+	}
+
+	return extensionFiles, nil
+}
+
 func detectLineSeparator(content string) string {
 	if strings.Contains(content, "\r\n") {
 		return "\r\n"
@@ -171,5 +288,17 @@ func reportExtensionResults(results []extensionResult) {
 		}
 
 		theme.Success(result.message)
+	}
+}
+
+func reportExtensionGroup(title string, extensions []string) {
+	theme.Title(title)
+	if len(extensions) == 0 {
+		color.White("    none")
+		return
+	}
+
+	for _, extension := range extensions {
+		color.White("    " + extension)
 	}
 }

--- a/commands/extensions.go
+++ b/commands/extensions.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"hjbdev/pvm/common"
 	"hjbdev/pvm/theme"
 	"os"
@@ -18,10 +19,23 @@ type extensionResult struct {
 	message string
 }
 
+type extensionStatusTag string
+
+const (
+	extensionTagEnabled   extensionStatusTag = "enabled"
+	extensionTagDisabled  extensionStatusTag = "disabled"
+	extensionTagAvailable extensionStatusTag = "available"
+	extensionTagMissing   extensionStatusTag = "missing file"
+)
+
+type extensionListItem struct {
+	Name string
+	Tags []extensionStatusTag
+}
+
 type extensionInventory struct {
-	Enabled   []string
-	Disabled  []string
-	Available []string
+	Extensions     []extensionListItem
+	ZendExtensions []extensionListItem
 }
 
 func Extensions(args []string) {
@@ -99,10 +113,8 @@ func listExtensions(versionPath string, ini string) {
 	}
 
 	inventory := buildExtensionInventory(ini, extensionFiles)
-
-	reportExtensionGroup("Enabled extensions", inventory.Enabled)
-	reportExtensionGroup("Disabled extensions", inventory.Disabled)
-	reportExtensionGroup("Available extensions", inventory.Available)
+	reportExtensionGroup("Extensions", inventory.Extensions)
+	reportExtensionGroup("Zend extensions", inventory.ZendExtensions)
 }
 
 func normalizeExtensions(raw string) []string {
@@ -134,7 +146,8 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 	changed := false
 
 	for _, extension := range extensions {
-		extensionStatus, lineNumber := common.GetExtensionStatus(currentIni, extension)
+		extensionStatus, lineNumber, directiveKind := common.GetDirectiveStatus(currentIni, extension)
+		label := extensionLabel(extension, directiveKind)
 
 		switch extensionStatus {
 		case common.ExtensionEnabled:
@@ -142,7 +155,7 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 				results = append(results, extensionResult{
 					name:    extension,
 					kind:    "success",
-					message: "Extension " + extension + " is already enabled.",
+					message: label + " is already enabled.",
 				})
 				continue
 			}
@@ -153,14 +166,14 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 			results = append(results, extensionResult{
 				name:    extension,
 				kind:    "success",
-				message: "Extension " + extension + " disabled.",
+				message: label + " disabled.",
 			})
 		case common.ExtensionDisabled:
 			if command == "disable" {
 				results = append(results, extensionResult{
 					name:    extension,
 					kind:    "success",
-					message: "Extension " + extension + " is already disabled.",
+					message: label + " is already disabled.",
 				})
 				continue
 			}
@@ -171,13 +184,13 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 			results = append(results, extensionResult{
 				name:    extension,
 				kind:    "success",
-				message: "Extension " + extension + " enabled.",
+				message: label + " enabled.",
 			})
 		default:
 			results = append(results, extensionResult{
 				name:    extension,
 				kind:    "error",
-				message: "Extension " + extension + " not found in php.ini",
+				message: "Extension or Zend extension " + extension + " not found in php.ini",
 			})
 		}
 	}
@@ -190,7 +203,8 @@ func applyExtensionChanges(ini string, command string, extensions []string) (str
 }
 
 func buildExtensionInventory(ini string, extensionFiles []string) extensionInventory {
-	configured := make(map[string]common.ExtensionStatus)
+	configuredExtensions := make(map[string]common.ExtensionStatus)
+	configuredZendExtensions := make(map[string]common.ExtensionStatus)
 	available := make(map[string]struct{}, len(extensionFiles))
 
 	for _, entry := range common.ParsePhpIniExtensions(ini) {
@@ -199,11 +213,12 @@ func buildExtensionInventory(ini string, extensionFiles []string) extensionInven
 			status = common.ExtensionEnabled
 		}
 
-		if existingStatus, ok := configured[entry.Name]; ok && existingStatus == common.ExtensionEnabled {
-			continue
+		switch entry.Kind {
+		case common.PhpIniZendExtensionDirective:
+			mergeExtensionStatus(configuredZendExtensions, entry.Name, status)
+		default:
+			mergeExtensionStatus(configuredExtensions, entry.Name, status)
 		}
-
-		configured[entry.Name] = status
 	}
 
 	for _, extensionFile := range extensionFiles {
@@ -216,38 +231,66 @@ func buildExtensionInventory(ini string, extensionFiles []string) extensionInven
 	}
 
 	inventory := extensionInventory{
-		Enabled:   make([]string, 0),
-		Disabled:  make([]string, 0),
-		Available: make([]string, 0),
+		Extensions:     make([]extensionListItem, 0),
+		ZendExtensions: make([]extensionListItem, 0),
 	}
 
-	for name, status := range configured {
-		label := name
+	for name, status := range configuredExtensions {
+		item := extensionListItem{Name: name, Tags: []extensionStatusTag{statusToTag(status)}}
 		if _, ok := available[name]; !ok {
-			label += " (missing file)"
+			item.Tags = append(item.Tags, extensionTagMissing)
 		}
-
-		if status == common.ExtensionEnabled {
-			inventory.Enabled = append(inventory.Enabled, label)
-			continue
-		}
-
-		inventory.Disabled = append(inventory.Disabled, label)
+		inventory.Extensions = append(inventory.Extensions, item)
 	}
 
 	for name := range available {
-		if _, ok := configured[name]; ok {
+		if _, ok := configuredExtensions[name]; ok {
+			continue
+		}
+		if _, ok := configuredZendExtensions[name]; ok {
 			continue
 		}
 
-		inventory.Available = append(inventory.Available, name)
+		inventory.Extensions = append(inventory.Extensions, extensionListItem{
+			Name: name,
+			Tags: []extensionStatusTag{extensionTagAvailable},
+		})
 	}
 
-	sort.Strings(inventory.Enabled)
-	sort.Strings(inventory.Disabled)
-	sort.Strings(inventory.Available)
+	for name, status := range configuredZendExtensions {
+		item := extensionListItem{Name: name, Tags: []extensionStatusTag{statusToTag(status)}}
+		if _, ok := available[name]; !ok {
+			item.Tags = append(item.Tags, extensionTagMissing)
+		}
+		inventory.ZendExtensions = append(inventory.ZendExtensions, item)
+	}
+
+	sortExtensionListItems(inventory.Extensions)
+	sortExtensionListItems(inventory.ZendExtensions)
 
 	return inventory
+}
+
+func mergeExtensionStatus(configured map[string]common.ExtensionStatus, name string, status common.ExtensionStatus) {
+	if existingStatus, ok := configured[name]; ok && existingStatus == common.ExtensionEnabled {
+		return
+	}
+
+	configured[name] = status
+}
+
+func statusToTag(status common.ExtensionStatus) extensionStatusTag {
+	if status == common.ExtensionEnabled {
+		return extensionTagEnabled
+	}
+
+	return extensionTagDisabled
+}
+
+func sortExtensionListItems(items []extensionListItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Name < items[j].Name
+	})
 }
 
 func readAvailableExtensionFiles(versionPath string) ([]string, error) {
@@ -291,14 +334,50 @@ func reportExtensionResults(results []extensionResult) {
 	}
 }
 
-func reportExtensionGroup(title string, extensions []string) {
+func extensionLabel(name string, kind common.PhpIniDirectiveKind) string {
+	if kind == common.PhpIniZendExtensionDirective {
+		return "Zend extension " + name
+	}
+
+	return "Extension " + name
+}
+
+func reportExtensionGroup(title string, items []extensionListItem) {
 	theme.Title(title)
-	if len(extensions) == 0 {
+	if len(items) == 0 {
 		color.White("    none")
 		return
 	}
 
-	for _, extension := range extensions {
-		color.White("    " + extension)
+	for _, item := range items {
+		color.White("    " + formatExtensionItem(item))
+	}
+}
+
+func formatExtensionItem(item extensionListItem) string {
+	parts := make([]string, 0, len(item.Tags)+1)
+	parts = append(parts, item.Name)
+
+	for _, tag := range item.Tags {
+		parts = append(parts, formatExtensionTag(tag))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func formatExtensionTag(tag extensionStatusTag) string {
+	label := fmt.Sprintf("[%s]", tag)
+
+	switch tag {
+	case extensionTagEnabled:
+		return color.GreenString(label)
+	case extensionTagDisabled:
+		return color.YellowString(label)
+	case extensionTagAvailable:
+		return color.CyanString(label)
+	case extensionTagMissing:
+		return color.RedString(label)
+	default:
+		return label
 	}
 }

--- a/commands/extensions.go
+++ b/commands/extensions.go
@@ -22,6 +22,7 @@ func Extensions(args []string) {
 	if currentVersion == "" {
 		theme.Error("You do not have an active PHP version.")
 		theme.Info("Select a PHP version with `pvm use <version>` first.")
+		return
 	}
 
 	command := args[0]
@@ -33,13 +34,13 @@ func Extensions(args []string) {
 	}
 
 	homeDir, err := os.UserHomeDir()
-
 	if err != nil {
-		panic(err)
+		theme.Error("Could not determine your home directory.")
+		return
 	}
 
-	// check if the version exists
-	if _, err := os.Stat(homeDir + "/.pvm/versions/" + currentVersion); os.IsNotExist(err) {
+	versionPath := filepath.Join(homeDir, ".pvm", "versions", currentVersion)
+	if _, err := os.Stat(versionPath); os.IsNotExist(err) {
 		theme.Error("The specified version does not exist.")
 		return
 	}
@@ -52,31 +53,44 @@ func Extensions(args []string) {
 }
 
 func handleExtension(ext string, command string, homeDir string, currentVersion string) {
-	ini := common.ReadPhpIni(homeDir + "/.pvm/versions/" + currentVersion + "/php.ini")
+	iniPath := filepath.Join(homeDir, ".pvm", "versions", currentVersion, "php.ini")
+	ini, err := common.ReadPhpIni(iniPath)
+	if err != nil {
+		theme.Error("Could not read php.ini for the active PHP version.")
+		return
+	}
+
 	splitIni := regexp.MustCompile(`\r?\n`).Split(ini, -1)
 	extensionStatus, lineNumber := common.GetExtensionStatus(ini, ext)
 
-	if extensionStatus == common.ExtensionEnabled {
+	switch extensionStatus {
+	case common.ExtensionEnabled:
 		if command == "enable" {
 			theme.Success("Extension " + ext + " is already enabled.")
 		} else {
 			disabledLine := ";" + splitIni[lineNumber]
 			splitIni[lineNumber] = disabledLine
 			newIni := strings.Join(splitIni, "\n")
-			os.WriteFile(filepath.Join(homeDir, ".pvm", "versions", currentVersion, "php.ini"), []byte(newIni), 0644)
-			theme.Success("Extension " + ext + " enabled.")
+			if err := os.WriteFile(iniPath, []byte(newIni), 0644); err != nil {
+				theme.Error("Could not update php.ini for the active PHP version.")
+				return
+			}
+			theme.Success("Extension " + ext + " disabled.")
 		}
-	} else if extensionStatus == common.ExtensionDisabled {
+	case common.ExtensionDisabled:
 		if command == "enable" {
 			enabledLine := strings.Replace(splitIni[lineNumber], ";", "", 1)
 			splitIni[lineNumber] = enabledLine
 			newIni := strings.Join(splitIni, "\n")
-			os.WriteFile(filepath.Join(homeDir, ".pvm", "versions", currentVersion, "php.ini"), []byte(newIni), 0644)
+			if err := os.WriteFile(iniPath, []byte(newIni), 0644); err != nil {
+				theme.Error("Could not update php.ini for the active PHP version.")
+				return
+			}
 			theme.Success("Extension " + ext + " enabled.")
 		} else {
 			theme.Success("Extension " + ext + " is already disabled.")
 		}
-	} else {
+	default:
 		theme.Error("Extension " + ext + " not found in php.ini")
 	}
 }

--- a/commands/extensions_test.go
+++ b/commands/extensions_test.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeExtensions_TrimsSkipsEmptyAndDeduplicates(t *testing.T) {
+	extensions := normalizeExtensions("curl, mbstring ,, curl,openssl ")
+
+	assert.Equal(t, []string{"curl", "mbstring", "openssl"}, extensions)
+}
+
+func TestApplyExtensionChanges_PreservesCRLFAndAppliesMultipleChanges(t *testing.T) {
+	ini := "extension=curl\r\n;extension=openssl\r\nextension=mysqli\r\n"
+
+	updated, results, changed := applyExtensionChanges(ini, "disable", []string{"curl", "openssl", "missing"})
+
+	assert.True(t, changed)
+	assert.Equal(t, ";extension=curl\r\n;extension=openssl\r\nextension=mysqli\r\n", updated)
+	assert.Equal(t, []extensionResult{
+		{name: "curl", kind: "success", message: "Extension curl disabled."},
+		{name: "openssl", kind: "success", message: "Extension openssl is already disabled."},
+		{name: "missing", kind: "error", message: "Extension missing not found in php.ini"},
+	}, results)
+}
+
+func TestExtensions_UpdatesPhpIniOnceForMultipleExtensions(t *testing.T) {
+	homeDir := t.TempDir()
+	setHomeDir(t, homeDir)
+	phpIniPath := writeActivePhpVersion(t, homeDir, "8.3.1", "extension=curl\r\n;extension=openssl\r\n")
+
+	Extensions([]string{"disable", "curl, openssl"})
+
+	contents, err := os.ReadFile(phpIniPath)
+	require.NoError(t, err)
+	assert.Equal(t, ";extension=curl\r\n;extension=openssl\r\n", string(contents))
+}
+
+func TestExtensions_HandlesMissingPhpIniGracefully(t *testing.T) {
+	homeDir := t.TempDir()
+	setHomeDir(t, homeDir)
+	writeActiveVersionMetadata(t, homeDir, "8.3.1")
+	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".pvm", "versions", "8.3.1"), 0755))
+
+	assert.NotPanics(t, func() {
+		Extensions([]string{"enable", "curl"})
+	})
+
+	_, err := os.Stat(filepath.Join(homeDir, ".pvm", "versions", "8.3.1", "php.ini"))
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestExtensions_AppliesKnownExtensionsEvenWhenSomeAreMissing(t *testing.T) {
+	homeDir := t.TempDir()
+	setHomeDir(t, homeDir)
+	phpIniPath := writeActivePhpVersion(t, homeDir, "8.3.1", ";extension=curl\n;extension=openssl\n")
+
+	Extensions([]string{"enable", "curl,missing,openssl"})
+
+	contents, err := os.ReadFile(phpIniPath)
+	require.NoError(t, err)
+	assert.Equal(t, "extension=curl\nextension=openssl\n", string(contents))
+}
+
+func setHomeDir(t *testing.T, homeDir string) {
+	t.Helper()
+	t.Setenv("HOME", homeDir)
+}
+
+func writeActiveVersionMetadata(t *testing.T, homeDir string, version string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".pvm"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".pvm", "version"), []byte(version), 0644))
+}
+
+func writeActivePhpVersion(t *testing.T, homeDir string, version string, ini string) string {
+	t.Helper()
+	writeActiveVersionMetadata(t, homeDir, version)
+	versionDir := filepath.Join(homeDir, ".pvm", "versions", version)
+	require.NoError(t, os.MkdirAll(versionDir, 0755))
+	phpIniPath := filepath.Join(versionDir, "php.ini")
+	require.NoError(t, os.WriteFile(phpIniPath, []byte(ini), 0644))
+	return phpIniPath
+}

--- a/commands/extensions_test.go
+++ b/commands/extensions_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 )
 
 func TestNormalizeExtensions_TrimsSkipsEmptyAndDeduplicates(t *testing.T) {
-	extensions := normalizeExtensions("curl, mbstring ,, curl,openssl ")
+	extensions := normalizeExtensions("curl, ext\\php_mbstring.dll ,, curl,openssl ")
 
 	assert.Equal(t, []string{"curl", "mbstring", "openssl"}, extensions)
 }
@@ -68,6 +69,49 @@ func TestExtensions_AppliesKnownExtensionsEvenWhenSomeAreMissing(t *testing.T) {
 	assert.Equal(t, "extension=curl\nextension=openssl\n", string(contents))
 }
 
+func TestBuildExtensionInventory_GroupsConfiguredAndAvailableExtensions(t *testing.T) {
+	ini := strings.Join([]string{
+		`extension=php_curl.dll`,
+		`;extension="ext\\php_openssl.dll"`,
+		`extension=missing`,
+	}, "\n")
+
+	inventory := buildExtensionInventory(ini, []string{"php_curl.dll", "php_mbstring.dll", "php_openssl.dll"})
+
+	assert.Equal(t, extensionInventory{
+		Enabled:   []string{"curl", "missing (missing file)"},
+		Disabled:  []string{"openssl"},
+		Available: []string{"mbstring"},
+	}, inventory)
+}
+
+func TestReadAvailableExtensionFiles_FiltersNonDllEntries(t *testing.T) {
+	versionPath := t.TempDir()
+	extDir := filepath.Join(versionPath, "ext")
+	require.NoError(t, os.MkdirAll(extDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(extDir, "php_curl.dll"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(extDir, "readme.txt"), []byte(""), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(extDir, "nested"), 0755))
+
+	files, err := readAvailableExtensionFiles(versionPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"php_curl.dll"}, files)
+}
+
+func TestBuildExtensionInventory_PrefersEnabledStateWhenExtensionAppearsTwice(t *testing.T) {
+	ini := strings.Join([]string{
+		`;extension=php_curl.dll`,
+		`extension=curl`,
+	}, "\n")
+
+	inventory := buildExtensionInventory(ini, []string{"php_curl.dll"})
+
+	assert.Equal(t, []string{"curl"}, inventory.Enabled)
+	assert.Empty(t, inventory.Disabled)
+	assert.Empty(t, inventory.Available)
+}
+
 func setHomeDir(t *testing.T, homeDir string) {
 	t.Helper()
 	t.Setenv("HOME", homeDir)
@@ -84,7 +128,10 @@ func writeActivePhpVersion(t *testing.T, homeDir string, version string, ini str
 	writeActiveVersionMetadata(t, homeDir, version)
 	versionDir := filepath.Join(homeDir, ".pvm", "versions", version)
 	require.NoError(t, os.MkdirAll(versionDir, 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(versionDir, "ext"), 0755))
 	phpIniPath := filepath.Join(versionDir, "php.ini")
 	require.NoError(t, os.WriteFile(phpIniPath, []byte(ini), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(versionDir, "ext", "php_curl.dll"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(versionDir, "ext", "php_openssl.dll"), []byte(""), 0644))
 	return phpIniPath
 }

--- a/commands/extensions_test.go
+++ b/commands/extensions_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +27,26 @@ func TestApplyExtensionChanges_PreservesCRLFAndAppliesMultipleChanges(t *testing
 	assert.Equal(t, []extensionResult{
 		{name: "curl", kind: "success", message: "Extension curl disabled."},
 		{name: "openssl", kind: "success", message: "Extension openssl is already disabled."},
-		{name: "missing", kind: "error", message: "Extension missing not found in php.ini"},
+		{name: "missing", kind: "error", message: "Extension or Zend extension missing not found in php.ini"},
+	}, results)
+}
+
+func TestApplyExtensionChanges_TogglesZendExtensions(t *testing.T) {
+	ini := joinLines(
+		`;zend_extension=php_xdebug.dll`,
+		`zend_extension=php_opcache.dll`,
+	)
+
+	updated, results, changed := applyExtensionChanges(ini, "enable", []string{"xdebug", "opcache"})
+
+	assert.True(t, changed)
+	assert.Equal(t, joinLines(
+		`zend_extension=php_xdebug.dll`,
+		`zend_extension=php_opcache.dll`,
+	), updated)
+	assert.Equal(t, []extensionResult{
+		{name: "xdebug", kind: "success", message: "Zend extension xdebug enabled."},
+		{name: "opcache", kind: "success", message: "Zend extension opcache is already enabled."},
 	}, results)
 }
 
@@ -47,6 +67,7 @@ func TestExtensions_HandlesMissingPhpIniGracefully(t *testing.T) {
 	setHomeDir(t, homeDir)
 	writeActiveVersionMetadata(t, homeDir, "8.3.1")
 	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".pvm", "versions", "8.3.1"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".pvm", "versions", "8.3.1", "ext"), 0755))
 
 	assert.NotPanics(t, func() {
 		Extensions([]string{"enable", "curl"})
@@ -69,20 +90,62 @@ func TestExtensions_AppliesKnownExtensionsEvenWhenSomeAreMissing(t *testing.T) {
 	assert.Equal(t, "extension=curl\nextension=openssl\n", string(contents))
 }
 
-func TestBuildExtensionInventory_GroupsConfiguredAndAvailableExtensions(t *testing.T) {
-	ini := strings.Join([]string{
+func TestExtensions_TogglesZendExtensionFromCli(t *testing.T) {
+	homeDir := t.TempDir()
+	setHomeDir(t, homeDir)
+	phpIniPath := writeActivePhpVersion(t, homeDir, "8.3.1", joinLines(
+		`;zend_extension=php_xdebug.dll`,
+		`extension=php_curl.dll`,
+	))
+	require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".pvm", "versions", "8.3.1", "ext", "php_xdebug.dll"), []byte(""), 0644))
+
+	Extensions([]string{"enable", "xdebug"})
+
+	contents, err := os.ReadFile(phpIniPath)
+	require.NoError(t, err)
+	assert.Equal(t, joinLines(
+		`zend_extension=php_xdebug.dll`,
+		`extension=php_curl.dll`,
+	), string(contents))
+}
+
+func TestBuildExtensionInventory_SeparatesRegularAndZendExtensions(t *testing.T) {
+	ini := joinLines(
 		`extension=php_curl.dll`,
 		`;extension="ext\\php_openssl.dll"`,
 		`extension=missing`,
-	}, "\n")
+		`zend_extension=php_xdebug.dll`,
+		`; zend_extension = php_opcache.dll`,
+	)
 
-	inventory := buildExtensionInventory(ini, []string{"php_curl.dll", "php_mbstring.dll", "php_openssl.dll"})
+	inventory := buildExtensionInventory(ini, []string{"php_curl.dll", "php_mbstring.dll", "php_openssl.dll", "php_opcache.dll"})
 
 	assert.Equal(t, extensionInventory{
-		Enabled:   []string{"curl", "missing (missing file)"},
-		Disabled:  []string{"openssl"},
-		Available: []string{"mbstring"},
+		Extensions: []extensionListItem{
+			{Name: "curl", Tags: []extensionStatusTag{extensionTagEnabled}},
+			{Name: "mbstring", Tags: []extensionStatusTag{extensionTagAvailable}},
+			{Name: "missing", Tags: []extensionStatusTag{extensionTagEnabled, extensionTagMissing}},
+			{Name: "openssl", Tags: []extensionStatusTag{extensionTagDisabled}},
+		},
+		ZendExtensions: []extensionListItem{
+			{Name: "opcache", Tags: []extensionStatusTag{extensionTagDisabled}},
+			{Name: "xdebug", Tags: []extensionStatusTag{extensionTagEnabled, extensionTagMissing}},
+		},
 	}, inventory)
+}
+
+func TestBuildExtensionInventory_PrefersEnabledStateWhenExtensionAppearsTwice(t *testing.T) {
+	ini := joinLines(
+		`;extension=php_curl.dll`,
+		`extension=curl`,
+		`;zend_extension=php_xdebug.dll`,
+		`zend_extension=php_xdebug.dll`,
+	)
+
+	inventory := buildExtensionInventory(ini, []string{"php_curl.dll", "php_xdebug.dll"})
+
+	assert.Equal(t, []extensionListItem{{Name: "curl", Tags: []extensionStatusTag{extensionTagEnabled}}}, inventory.Extensions)
+	assert.Equal(t, []extensionListItem{{Name: "xdebug", Tags: []extensionStatusTag{extensionTagEnabled}}}, inventory.ZendExtensions)
 }
 
 func TestReadAvailableExtensionFiles_FiltersNonDllEntries(t *testing.T) {
@@ -99,17 +162,19 @@ func TestReadAvailableExtensionFiles_FiltersNonDllEntries(t *testing.T) {
 	assert.Equal(t, []string{"php_curl.dll"}, files)
 }
 
-func TestBuildExtensionInventory_PrefersEnabledStateWhenExtensionAppearsTwice(t *testing.T) {
-	ini := strings.Join([]string{
-		`;extension=php_curl.dll`,
-		`extension=curl`,
-	}, "\n")
+func TestFormatExtensionItem_FormatsNameBeforeTags(t *testing.T) {
+	previousNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() {
+		color.NoColor = previousNoColor
+	})
 
-	inventory := buildExtensionInventory(ini, []string{"php_curl.dll"})
+	formatted := formatExtensionItem(extensionListItem{
+		Name: "xdebug",
+		Tags: []extensionStatusTag{extensionTagEnabled, extensionTagMissing},
+	})
 
-	assert.Equal(t, []string{"curl"}, inventory.Enabled)
-	assert.Empty(t, inventory.Disabled)
-	assert.Empty(t, inventory.Available)
+	assert.Equal(t, "xdebug [enabled] [missing file]", formatted)
 }
 
 func setHomeDir(t *testing.T, homeDir string) {
@@ -127,11 +192,14 @@ func writeActivePhpVersion(t *testing.T, homeDir string, version string, ini str
 	t.Helper()
 	writeActiveVersionMetadata(t, homeDir, version)
 	versionDir := filepath.Join(homeDir, ".pvm", "versions", version)
-	require.NoError(t, os.MkdirAll(versionDir, 0755))
 	require.NoError(t, os.MkdirAll(filepath.Join(versionDir, "ext"), 0755))
 	phpIniPath := filepath.Join(versionDir, "php.ini")
 	require.NoError(t, os.WriteFile(phpIniPath, []byte(ini), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(versionDir, "ext", "php_curl.dll"), []byte(""), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(versionDir, "ext", "php_openssl.dll"), []byte(""), 0644))
 	return phpIniPath
+}
+
+func joinLines(lines ...string) string {
+	return strings.Join(lines, "\n")
 }

--- a/commands/extensions_test.go
+++ b/commands/extensions_test.go
@@ -50,6 +50,40 @@ func TestApplyExtensionChanges_TogglesZendExtensions(t *testing.T) {
 	}, results)
 }
 
+func TestApplyExtensionChanges_DisablesAllDuplicateDirectives(t *testing.T) {
+	ini := joinLines(
+		`extension=php_curl.dll`,
+		`;extension=php_curl.dll`,
+		`extension=php_curl.dll`,
+	)
+
+	updated, results, changed := applyExtensionChanges(ini, "disable", []string{"curl"})
+
+	assert.True(t, changed)
+	assert.Equal(t, joinLines(
+		`;extension=php_curl.dll`,
+		`;extension=php_curl.dll`,
+		`;extension=php_curl.dll`,
+	), updated)
+	assert.Equal(t, []extensionResult{{name: "curl", kind: "success", message: "Extension curl disabled."}}, results)
+}
+
+func TestApplyExtensionChanges_EnablesAllDuplicateZendDirectives(t *testing.T) {
+	ini := joinLines(
+		`;zend_extension=php_xdebug.dll`,
+		`;zend_extension=php_xdebug.dll`,
+	)
+
+	updated, results, changed := applyExtensionChanges(ini, "enable", []string{"xdebug"})
+
+	assert.True(t, changed)
+	assert.Equal(t, joinLines(
+		`zend_extension=php_xdebug.dll`,
+		`zend_extension=php_xdebug.dll`,
+	), updated)
+	assert.Equal(t, []extensionResult{{name: "xdebug", kind: "success", message: "Zend extension xdebug enabled."}}, results)
+}
+
 func TestExtensions_UpdatesPhpIniOnceForMultipleExtensions(t *testing.T) {
 	homeDir := t.TempDir()
 	setHomeDir(t, homeDir)
@@ -107,6 +141,22 @@ func TestExtensions_TogglesZendExtensionFromCli(t *testing.T) {
 		`zend_extension=php_xdebug.dll`,
 		`extension=php_curl.dll`,
 	), string(contents))
+}
+
+func TestExtensions_DoesNotTouchPhpIniWithoutActiveVersionMetadata(t *testing.T) {
+	homeDir := t.TempDir()
+	setHomeDir(t, homeDir)
+	versionDir := filepath.Join(homeDir, ".pvm", "versions", "8.3.1")
+	require.NoError(t, os.MkdirAll(filepath.Join(versionDir, "ext"), 0755))
+	phpIniPath := filepath.Join(versionDir, "php.ini")
+	require.NoError(t, os.WriteFile(phpIniPath, []byte(";extension=curl\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(versionDir, "ext", "php_curl.dll"), []byte(""), 0644))
+
+	Extensions([]string{"enable", "curl"})
+
+	contents, err := os.ReadFile(phpIniPath)
+	require.NoError(t, err)
+	assert.Equal(t, ";extension=curl\n", string(contents))
 }
 
 func TestBuildExtensionInventory_SeparatesRegularAndZendExtensions(t *testing.T) {

--- a/commands/help.go
+++ b/commands/help.go
@@ -14,6 +14,7 @@ func Help(notFoundError bool) {
 	}
 
 	fmt.Println("Available Commands:")
+	fmt.Println("    extensions")
 	fmt.Println("    help")
 	fmt.Println("    install")
 	fmt.Println("    list")

--- a/commands/list.go
+++ b/commands/list.go
@@ -1,9 +1,11 @@
 package commands
 
 import (
+	"hjbdev/pvm/common"
 	"hjbdev/pvm/theme"
 	"log"
 	"os"
+
 	"github.com/fatih/color"
 )
 
@@ -35,8 +37,14 @@ func List() {
 
 	theme.Title("Installed PHP versions")
 
+	currentVersion := common.GetCurrentVersionFolder()
+
 	// print all folders
 	for _, version := range versions {
-		color.White("    " + version.Name())
+		if version.Name() == currentVersion {
+			color.White("    " + version.Name() + " (current)")
+		} else {
+			color.White("    " + version.Name())
+		}
 	}
 }

--- a/commands/list_test.go
+++ b/commands/list_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestList_MarksCurrentVersionFromVersionMetadata(t *testing.T) {
+	homeDir := t.TempDir()
+	setHomeDir(t, homeDir)
+	writeInstalledVersion(t, homeDir, "8.2.15")
+	writeInstalledVersion(t, homeDir, "8.3.1")
+	writeActiveVersionMetadata(t, homeDir, "8.3.1")
+
+	output := captureStdout(t, func() {
+		List()
+	})
+
+	assert.Contains(t, output, "8.3.1 (current)")
+	assert.NotContains(t, output, "8.2.15 (current)")
+}
+
+func TestList_SkipsCurrentMarkerWithoutVersionMetadata(t *testing.T) {
+	homeDir := t.TempDir()
+	setHomeDir(t, homeDir)
+	writeInstalledVersion(t, homeDir, "8.3.1")
+
+	output := captureStdout(t, func() {
+		List()
+	})
+
+	assert.Contains(t, output, "8.3.1")
+	assert.NotContains(t, output, "(current)")
+}
+
+func writeInstalledVersion(t *testing.T, homeDir string, version string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".pvm", "versions", version), 0755))
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	previousStdout := os.Stdout
+	previousColorOutput := color.Output
+	previousNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() {
+		os.Stdout = previousStdout
+		color.Output = previousColorOutput
+		color.NoColor = previousNoColor
+	})
+
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = writer
+	color.Output = writer
+
+	outputCh := make(chan string, 1)
+	go func() {
+		var buffer bytes.Buffer
+		_, _ = io.Copy(&buffer, reader)
+		outputCh <- buffer.String()
+	}()
+
+	fn()
+	require.NoError(t, writer.Close())
+
+	output := <-outputCh
+	require.NoError(t, reader.Close())
+	return output
+}

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -271,13 +271,19 @@ func ReadPhpIni(path string) (string, error) {
 
 type ExtensionStatus int
 
+type PhpIniDirectiveKind string
+
 type PhpIniExtension struct {
 	Name    string
 	Enabled bool
 	Line    int
+	Kind    PhpIniDirectiveKind
 }
 
 const (
+	PhpIniExtensionDirective     PhpIniDirectiveKind = "extension"
+	PhpIniZendExtensionDirective PhpIniDirectiveKind = "zend_extension"
+
 	ExtensionEnabled ExtensionStatus = iota + 1
 	ExtensionDisabled
 	ExtensionNotFound
@@ -287,6 +293,9 @@ func GetExtensionStatus(ini string, extension string) (ExtensionStatus, int) {
 	normalizedExtension := NormalizeExtensionName(extension)
 
 	for _, parsedExtension := range ParsePhpIniExtensions(ini) {
+		if parsedExtension.Kind != PhpIniExtensionDirective {
+			continue
+		}
 		if parsedExtension.Name != normalizedExtension {
 			continue
 		}
@@ -301,27 +310,54 @@ func GetExtensionStatus(ini string, extension string) (ExtensionStatus, int) {
 	return ExtensionNotFound, -1
 }
 
+func GetDirectiveStatus(ini string, extension string) (ExtensionStatus, int, PhpIniDirectiveKind) {
+	normalizedExtension := NormalizeExtensionName(extension)
+
+	for _, parsedExtension := range ParsePhpIniExtensions(ini) {
+		if parsedExtension.Name != normalizedExtension {
+			continue
+		}
+
+		if parsedExtension.Enabled {
+			return ExtensionEnabled, parsedExtension.Line, parsedExtension.Kind
+		}
+
+		return ExtensionDisabled, parsedExtension.Line, parsedExtension.Kind
+	}
+
+	return ExtensionNotFound, -1, ""
+}
+
 func ParsePhpIniExtensions(ini string) []PhpIniExtension {
 	lines := regexp.MustCompile(`\r?\n`).Split(ini, -1)
-	extensionRe := regexp.MustCompile(`extension\s*=\s*(.+)$`)
+	directiveRe := regexp.MustCompile(`^\s*(;?)\s*(zend_extension|extension)\s*=\s*(?:"([^"]+)"|'([^']+)'|([^;\s]+))\s*(?:;.*)?$`)
 	extensions := make([]PhpIniExtension, 0)
 
 	for index, line := range lines {
-		matches := extensionRe.FindStringSubmatch(line)
+		matches := directiveRe.FindStringSubmatch(line)
 		if len(matches) == 0 {
 			continue
 		}
 
-		name := NormalizeExtensionName(matches[1])
+		rawValue := matches[3]
+		if rawValue == "" {
+			rawValue = matches[4]
+		}
+		if rawValue == "" {
+			rawValue = matches[5]
+		}
+
+		name := NormalizeExtensionName(rawValue)
 		if name == "" {
 			continue
 		}
 
-		trimmedLine := strings.TrimSpace(line)
+		kind := PhpIniDirectiveKind(matches[2])
 		extensions = append(extensions, PhpIniExtension{
 			Name:    name,
-			Enabled: !strings.HasPrefix(trimmedLine, ";"),
+			Enabled: matches[1] != ";",
 			Line:    index,
+			Kind:    kind,
 		})
 	}
 

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -270,6 +271,12 @@ func ReadPhpIni(path string) (string, error) {
 
 type ExtensionStatus int
 
+type PhpIniExtension struct {
+	Name    string
+	Enabled bool
+	Line    int
+}
+
 const (
 	ExtensionEnabled ExtensionStatus = iota + 1
 	ExtensionDisabled
@@ -277,23 +284,66 @@ const (
 )
 
 func GetExtensionStatus(ini string, extension string) (ExtensionStatus, int) {
-	lines := regexp.MustCompile(`\r?\n`).Split(ini, -1)
-	extensionRe := regexp.MustCompile(`extension\s*=\s*["']?([^"']+)["']?`)
+	normalizedExtension := NormalizeExtensionName(extension)
 
-	for index, line := range lines {
-		extensionMatches := extensionRe.FindStringSubmatch(line)
-		if len(extensionMatches) == 0 {
+	for _, parsedExtension := range ParsePhpIniExtensions(ini) {
+		if parsedExtension.Name != normalizedExtension {
 			continue
 		}
 
-		if extensionMatches[1] == extension {
-			noWhitespace := strings.TrimSpace(lines[index])
-			if strings.HasPrefix(noWhitespace, ";") {
-				return ExtensionDisabled, index
-			}
-			return ExtensionEnabled, index
+		if parsedExtension.Enabled {
+			return ExtensionEnabled, parsedExtension.Line
 		}
+
+		return ExtensionDisabled, parsedExtension.Line
 	}
 
 	return ExtensionNotFound, -1
+}
+
+func ParsePhpIniExtensions(ini string) []PhpIniExtension {
+	lines := regexp.MustCompile(`\r?\n`).Split(ini, -1)
+	extensionRe := regexp.MustCompile(`extension\s*=\s*(.+)$`)
+	extensions := make([]PhpIniExtension, 0)
+
+	for index, line := range lines {
+		matches := extensionRe.FindStringSubmatch(line)
+		if len(matches) == 0 {
+			continue
+		}
+
+		name := NormalizeExtensionName(matches[1])
+		if name == "" {
+			continue
+		}
+
+		trimmedLine := strings.TrimSpace(line)
+		extensions = append(extensions, PhpIniExtension{
+			Name:    name,
+			Enabled: !strings.HasPrefix(trimmedLine, ";"),
+			Line:    index,
+		})
+	}
+
+	return extensions
+}
+
+func NormalizeExtensionName(value string) string {
+	normalized := strings.TrimSpace(value)
+
+	if idx := strings.Index(normalized, ";"); idx != -1 {
+		normalized = strings.TrimSpace(normalized[:idx])
+	}
+
+	normalized = strings.Trim(normalized, `"'`)
+	if normalized == "" {
+		return ""
+	}
+
+	normalized = strings.ReplaceAll(normalized, `\`, "/")
+	normalized = strings.ToLower(path.Base(normalized))
+	normalized = strings.TrimSuffix(normalized, ".dll")
+	normalized = strings.TrimPrefix(normalized, "php_")
+
+	return strings.TrimSpace(normalized)
 }

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -259,13 +259,13 @@ func GetCurrentVersionFolder() string {
 	return string(content)
 }
 
-func ReadPhpIni(path string) string {
+func ReadPhpIni(path string) (string, error) {
 	file, err := os.ReadFile(path)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
-	return string(file)
+	return string(file), nil
 }
 
 type ExtensionStatus int
@@ -278,9 +278,10 @@ const (
 
 func GetExtensionStatus(ini string, extension string) (ExtensionStatus, int) {
 	lines := regexp.MustCompile(`\r?\n`).Split(ini, -1)
+	extensionRe := regexp.MustCompile(`extension\s*=\s*["']?([^"']+)["']?`)
 
 	for index, line := range lines {
-		extensionMatches := regexp.MustCompile(`extension\s*=\s*["']?([^"']+)["']?`).FindStringSubmatch(line)
+		extensionMatches := extensionRe.FindStringSubmatch(line)
 		if len(extensionMatches) == 0 {
 			continue
 		}

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -173,3 +173,25 @@ func Test_GetDirectiveStatus_FindsZendAndRegularExtensions(t *testing.T) {
 	assert.Equal(t, 1, line)
 	assert.Equal(t, PhpIniExtensionDirective, kind)
 }
+
+func Test_ParsePhpIniExtensions_IgnoresBogusCommentExamplesInRealIni(t *testing.T) {
+	fixturePath := filepath.Join("..", "php8.5.ini-production")
+	body, err := os.ReadFile(fixturePath)
+	require.NoError(t, err)
+
+	ini := string(body) + "\n; bogus example: extension='php_fake.dll') is supported for legacy reasons\n; bogus example: zend_extension=/tmp/not-real-xdebug.dll is documented here\n"
+
+	extensions := ParsePhpIniExtensions(ini)
+	names := make([]string, 0, len(extensions))
+	for _, extension := range extensions {
+		names = append(names, extension.Name)
+	}
+
+	assert.NotContains(t, names, "fake")
+	assert.NotContains(t, names, "not-real-xdebug")
+	assert.NotContains(t, names, "php_<ext>")
+	assert.NotContains(t, names, "ext>) syntax")
+	assert.Contains(t, names, "curl")
+	assert.Contains(t, names, "openssl")
+	assert.Contains(t, names, "mbstring")
+}

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -115,13 +115,61 @@ func Test_ParsePhpIniExtensions_ParsesNormalizedEntries(t *testing.T) {
 		`extension=php_curl.dll`,
 		`;extension="ext\\php_openssl.dll"`,
 		`extension=C:/php/ext/php_mbstring.dll ; comment`,
+		`zend_extension=php_xdebug.dll`,
 	}, "\n")
 
 	extensions := ParsePhpIniExtensions(ini)
 
 	assert.Equal(t, []PhpIniExtension{
-		{Name: "curl", Enabled: true, Line: 0},
-		{Name: "openssl", Enabled: false, Line: 1},
-		{Name: "mbstring", Enabled: true, Line: 2},
+		{Name: "curl", Enabled: true, Line: 0, Kind: PhpIniExtensionDirective},
+		{Name: "openssl", Enabled: false, Line: 1, Kind: PhpIniExtensionDirective},
+		{Name: "mbstring", Enabled: true, Line: 2, Kind: PhpIniExtensionDirective},
+		{Name: "xdebug", Enabled: true, Line: 3, Kind: PhpIniZendExtensionDirective},
 	}, extensions)
+}
+
+func Test_ParsePhpIniExtensions_IgnoresCommentProse(t *testing.T) {
+	ini := strings.Join([]string{
+		`; <ext> is the name of the extension. Do not put extension=foo in this comment.`,
+		`; zend_extension=/full/path/to/xdebug.dll is also documented here`,
+		`extension=php_curl.dll`,
+	}, "\n")
+
+	extensions := ParsePhpIniExtensions(ini)
+
+	assert.Equal(t, []PhpIniExtension{
+		{Name: "curl", Enabled: true, Line: 2, Kind: PhpIniExtensionDirective},
+	}, extensions)
+}
+
+func Test_GetExtensionStatus_IgnoresZendExtensions(t *testing.T) {
+	ini := strings.Join([]string{
+		`zend_extension=php_xdebug.dll`,
+		`extension=php_curl.dll`,
+	}, "\n")
+
+	status, line := GetExtensionStatus(ini, "xdebug")
+	assert.Equal(t, ExtensionNotFound, status)
+	assert.Equal(t, -1, line)
+
+	status, line = GetExtensionStatus(ini, "curl")
+	assert.Equal(t, ExtensionEnabled, status)
+	assert.Equal(t, 1, line)
+}
+
+func Test_GetDirectiveStatus_FindsZendAndRegularExtensions(t *testing.T) {
+	ini := strings.Join([]string{
+		`;zend_extension=php_xdebug.dll`,
+		`extension=php_curl.dll`,
+	}, "\n")
+
+	status, line, kind := GetDirectiveStatus(ini, "xdebug")
+	assert.Equal(t, ExtensionDisabled, status)
+	assert.Equal(t, 0, line)
+	assert.Equal(t, PhpIniZendExtensionDirective, kind)
+
+	status, line, kind = GetDirectiveStatus(ini, "curl")
+	assert.Equal(t, ExtensionEnabled, status)
+	assert.Equal(t, 1, line)
+	assert.Equal(t, PhpIniExtensionDirective, kind)
 }

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -175,11 +175,19 @@ func Test_GetDirectiveStatus_FindsZendAndRegularExtensions(t *testing.T) {
 }
 
 func Test_ParsePhpIniExtensions_IgnoresBogusCommentExamplesInRealIni(t *testing.T) {
-	fixturePath := filepath.Join("..", "php8.5.ini-production")
-	body, err := os.ReadFile(fixturePath)
-	require.NoError(t, err)
-
-	ini := string(body) + "\n; bogus example: extension='php_fake.dll') is supported for legacy reasons\n; bogus example: zend_extension=/tmp/not-real-xdebug.dll is documented here\n"
+	ini := strings.Join([]string{
+		`; Notes for Windows environments :`,
+		`;   extension=mysqli`,
+		`;   extension=/path/to/extension/mysqli.so`,
+		`; Note : The syntax used in previous PHP versions ('extension=<ext>.so' and`,
+		`; 'extension='php_<ext>.dll') is supported for legacy reasons and may be`,
+		`; move to the new ('extension=<ext>) syntax.`,
+		`;extension=curl`,
+		`;extension=mbstring`,
+		`;extension=openssl`,
+		`; bogus example: extension='php_fake.dll') is supported for legacy reasons`,
+		`; bogus example: zend_extension=/tmp/not-real-xdebug.dll is documented here`,
+	}, "\n")
 
 	extensions := ParsePhpIniExtensions(ini)
 	names := make([]string, 0, len(extensions))

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -1,9 +1,12 @@
 package common
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ParsePHPVersions_ParsesDownloadsPHPNetArchiveListing(t *testing.T) {
@@ -64,4 +67,38 @@ func Test_Version_Compare(t *testing.T) {
 	v7 := Version{Major: 1, Minor: 2}
 
 	assert.Equal(t, v6.LessThan(v7), false)
+}
+
+func Test_ReadPhpIni_ReturnsFileContents(t *testing.T) {
+	tempDir := t.TempDir()
+	phpIniPath := filepath.Join(tempDir, "php.ini")
+	require.NoError(t, os.WriteFile(phpIniPath, []byte("extension=curl"), 0644))
+
+	contents, err := ReadPhpIni(phpIniPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, "extension=curl", contents)
+}
+
+func Test_ReadPhpIni_ReturnsErrorForMissingFile(t *testing.T) {
+	contents, err := ReadPhpIni(filepath.Join(t.TempDir(), "missing.ini"))
+
+	assert.Error(t, err)
+	assert.Equal(t, "", contents)
+}
+
+func Test_GetExtensionStatus_DetectsEnabledAndDisabledExtensions(t *testing.T) {
+	ini := "extension=curl\n;extension=openssl\n"
+
+	status, line := GetExtensionStatus(ini, "curl")
+	assert.Equal(t, ExtensionEnabled, status)
+	assert.Equal(t, 0, line)
+
+	status, line = GetExtensionStatus(ini, "openssl")
+	assert.Equal(t, ExtensionDisabled, status)
+	assert.Equal(t, 1, line)
+
+	status, line = GetExtensionStatus(ini, "mbstring")
+	assert.Equal(t, ExtensionNotFound, status)
+	assert.Equal(t, -1, line)
 }

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,4 +102,26 @@ func Test_GetExtensionStatus_DetectsEnabledAndDisabledExtensions(t *testing.T) {
 	status, line = GetExtensionStatus(ini, "mbstring")
 	assert.Equal(t, ExtensionNotFound, status)
 	assert.Equal(t, -1, line)
+}
+
+func Test_NormalizeExtensionName_HandlesPathsQuotesAndDllPrefix(t *testing.T) {
+	assert.Equal(t, "curl", NormalizeExtensionName(`"ext\\php_curl.dll" ; comment`))
+	assert.Equal(t, "openssl", NormalizeExtensionName(`C:/php/ext/php_openssl.dll`))
+	assert.Equal(t, "xdebug", NormalizeExtensionName(`xdebug`))
+}
+
+func Test_ParsePhpIniExtensions_ParsesNormalizedEntries(t *testing.T) {
+	ini := strings.Join([]string{
+		`extension=php_curl.dll`,
+		`;extension="ext\\php_openssl.dll"`,
+		`extension=C:/php/ext/php_mbstring.dll ; comment`,
+	}, "\n")
+
+	extensions := ParsePhpIniExtensions(ini)
+
+	assert.Equal(t, []PhpIniExtension{
+		{Name: "curl", Enabled: true, Line: 0},
+		{Name: "openssl", Enabled: false, Line: 1},
+		{Name: "mbstring", Enabled: true, Line: 2},
+	}, extensions)
 }

--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ func main() {
 		commands.Install(args)
 	case "use":
 		commands.Use(args[1:])
+	case "extensions":
+		commands.Extensions(args[1:])
 	default:
 		commands.Help(true)
 	}


### PR DESCRIPTION
This PR adds functionality for toggling extensions in the php.ini with `pvm extensions <enable|disable> <ext>`

Older installs may need to run `pvm use <version>` once after upgrading, because the active version is now stored in `~/.pvm/version`