### PR TITLE
injecting PHP_FOLDER environment var in bat / sh files

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -7,7 +7,7 @@ import (
 
 func Help(notFoundError bool) {
 	theme.Title("pvm: PHP Version Manager")
-	theme.Info("Version 1.1.1")
+	theme.Info("Version 1.1.2")
 
 	if notFoundError {
 		theme.Error("Command not found")

--- a/commands/use.go
+++ b/commands/use.go
@@ -111,12 +111,14 @@ func Use(args []string) {
 	versionFolderPath := filepath.Join(homeDir, ".pvm", "versions", selectedVersion.folder.Name())
 	versionPath := filepath.Join(versionFolderPath, "php.exe")
 	versionPathCGI := filepath.Join(versionFolderPath, "php-cgi.exe")
+    envPHPRC := "PHPRC=" + versionFolderPath
 
 	// create bat script for php
 	batCommand := "@echo off \n"
-	batCommand = batCommand + "set filepath=\"" + versionPath + "\"\n"
-	batCommand = batCommand + "set arguments=%*\n"
-	batCommand = batCommand + "%filepath% %arguments%\n"
+    batCommand += "set " + envPHPRC + "\n"
+	batCommand += "set filepath=\"" + versionPath + "\"\n"
+	batCommand += "set arguments=%*\n"
+	batCommand += "%filepath% %arguments%\n"
 
 	err = os.WriteFile(batPath, []byte(batCommand), 0755)
 
@@ -126,8 +128,8 @@ func Use(args []string) {
 
 	// create sh script for php
 	shCommand := "#!/bin/bash\n"
-	shCommand = shCommand + "filepath=\"" + versionPath + "\"\n"
-	shCommand = shCommand + "\"$filepath\" \"$@\""
+	shCommand += "filepath=\"" + versionPath + "\"\n"
+	shCommand += envPHPRC + " \"$filepath\" \"$@\""
 
 	err = os.WriteFile(shPath, []byte(shCommand), 0755)
 
@@ -137,9 +139,10 @@ func Use(args []string) {
 
 	// create bat script for php-cgi
 	batCommandCGI := "@echo off \n"
-	batCommandCGI = batCommandCGI + "set filepath=\"" + versionPathCGI + "\"\n"
-	batCommandCGI = batCommandCGI + "set arguments=%*\n"
-	batCommandCGI = batCommandCGI + "%filepath% %arguments%\n"
+    batCommandCGI += "set " + envPHPRC + "\n"
+	batCommandCGI += "set filepath=\"" + versionPathCGI + "\"\n"
+	batCommandCGI += "set arguments=%*\n"
+	batCommandCGI += "%filepath% %arguments%\n"
 
 	err = os.WriteFile(batPathCGI, []byte(batCommandCGI), 0755)
 
@@ -149,8 +152,8 @@ func Use(args []string) {
 
 	// create sh script for php-cgi
 	shCommandCGI := "#!/bin/bash\n"
-	shCommandCGI = shCommandCGI + "filepath=\"" + versionPathCGI + "\"\n"
-	shCommandCGI = shCommandCGI + "\"$filepath\" \"$@\""
+	shCommandCGI += "filepath=\"" + versionPathCGI + "\"\n"
+	shCommandCGI += envPHPRC + " \"$filepath\" \"$@\""
 
 	err = os.WriteFile(shPathCGI, []byte(shCommandCGI), 0755)
 

--- a/commands/use.go
+++ b/commands/use.go
@@ -111,11 +111,11 @@ func Use(args []string) {
 	versionFolderPath := filepath.Join(homeDir, ".pvm", "versions", selectedVersion.folder.Name())
 	versionPath := filepath.Join(versionFolderPath, "php.exe")
 	versionPathCGI := filepath.Join(versionFolderPath, "php-cgi.exe")
-    envPHPRC := "PHPRC=" + versionFolderPath
+	envPHPFolder := "PHP_FOLDER=" + versionFolderPath
 
 	// create bat script for php
 	batCommand := "@echo off \n"
-    batCommand += "set " + envPHPRC + "\n"
+	batCommand += "set " + envPHPFolder + "\n"
 	batCommand += "set filepath=\"" + versionPath + "\"\n"
 	batCommand += "set arguments=%*\n"
 	batCommand += "%filepath% %arguments%\n"
@@ -129,7 +129,7 @@ func Use(args []string) {
 	// create sh script for php
 	shCommand := "#!/bin/bash\n"
 	shCommand += "filepath=\"" + versionPath + "\"\n"
-	shCommand += envPHPRC + " \"$filepath\" \"$@\""
+	shCommand += envPHPFolder + " \"$filepath\" \"$@\""
 
 	err = os.WriteFile(shPath, []byte(shCommand), 0755)
 
@@ -139,7 +139,7 @@ func Use(args []string) {
 
 	// create bat script for php-cgi
 	batCommandCGI := "@echo off \n"
-    batCommandCGI += "set " + envPHPRC + "\n"
+	batCommandCGI += "set " + envPHPFolder + "\n"
 	batCommandCGI += "set filepath=\"" + versionPathCGI + "\"\n"
 	batCommandCGI += "set arguments=%*\n"
 	batCommandCGI += "%filepath% %arguments%\n"
@@ -153,7 +153,7 @@ func Use(args []string) {
 	// create sh script for php-cgi
 	shCommandCGI := "#!/bin/bash\n"
 	shCommandCGI += "filepath=\"" + versionPathCGI + "\"\n"
-	shCommandCGI += envPHPRC + " \"$filepath\" \"$@\""
+	shCommandCGI += envPHPFolder + " \"$filepath\" \"$@\""
 
 	err = os.WriteFile(shPathCGI, []byte(shCommandCGI), 0755)
 


### PR DESCRIPTION
Hello devs!

I made this change to inject the php directory path as environment variable. In this way is possible to use $PHP_FOLDER in php.ini configuration file. With this variable, I can set paths in php.ini relative to php directory.

e.g.:
```ini
auto_prepend_file = ${PHP_FOLDER}\scripts\auto_prepend.php
auto_append_file = ${PHP_FOLDER}\scripts\auto_append.php
error_log = ${PHP_FOLDER}\logs\php_error.log
```