### PR TITLE
Feature/composer

### DIFF
--- a/commands/help.go
+++ b/commands/help.go
@@ -7,7 +7,7 @@ import (
 
 func Help(notFoundError bool) {
 	theme.Title("pvm: PHP Version Manager")
-	theme.Info("Version 1.1.1")
+	theme.Info("Version 1.2.0")
 
 	if notFoundError {
 		theme.Error("Command not found")

--- a/commands/install.go
+++ b/commands/install.go
@@ -188,7 +188,13 @@ func Install(args []string) {
 	}
 
 	// install composer
-	composerPath := filepath.Join(phpPath, "composer", "composer.phar")
+	composerFolderPath := filepath.Join(phpPath, "composer")
+	if _, err := os.Stat(composerFolderPath); os.IsNotExist(err) {
+		theme.Info("Creating .pvm/versions folder in home directory")
+		os.Mkdir(composerFolderPath, 0755)
+	}
+
+	composerPath := filepath.Join(composerFolderPath, "composer.phar")
 	composerUrl := "https://getcomposer.org/download/latest-stable/composer.phar"
 	if desiredVersion.LessThan(common.Version{Major: 7, Minor: 2}) {
 		composerUrl = "https://getcomposer.org/download/latest-2.2.x/composer.phar"

--- a/commands/install.go
+++ b/commands/install.go
@@ -188,7 +188,7 @@ func Install(args []string) {
 	}
 
 	// install composer
-	composerPath := filepath.Join(phpPath, "composer.phar")
+	composerPath := filepath.Join(phpPath, "composer", "composer.phar")
 	composerUrl := "https://getcomposer.org/download/latest-stable/composer.phar"
 	if desiredVersion.LessThan(common.Version{Major: 7, Minor: 2}) {
 		composerUrl = "https://getcomposer.org/download/latest-2.2.x/composer.phar"

--- a/commands/install.go
+++ b/commands/install.go
@@ -143,62 +143,59 @@ func Install(args []string) {
 	}
 
 	// check if .pvm folder exists
-	if _, err := os.Stat(homeDir + "/.pvm"); os.IsNotExist(err) {
+	pvmPath := filepath.Join(homeDir, ".pvm")
+	if _, err := os.Stat(pvmPath); os.IsNotExist(err) {
 		theme.Info("Creating .pvm folder in home directory")
-		os.Mkdir(homeDir+"/.pvm", 0755)
+		os.Mkdir(pvmPath, 0755)
 	}
 
 	// check if .pvm/versions folder exists
-	if _, err := os.Stat(homeDir + "/.pvm/versions"); os.IsNotExist(err) {
+	versionsPath := filepath.Join(pvmPath, "versions")
+	if _, err := os.Stat(versionsPath); os.IsNotExist(err) {
 		theme.Info("Creating .pvm/versions folder in home directory")
-		os.Mkdir(homeDir+"/.pvm/versions", 0755)
+		os.Mkdir(versionsPath, 0755)
 	}
 
 	theme.Info("Downloading")
 
-	// Get the data
-	downloadResponse, err := http.Get("https://windows.php.net" + desiredVersion.Url)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	defer downloadResponse.Body.Close()
-
 	// zip filename from url
+	zipUrl := "https://windows.php.net" + desiredVersion.Url
 	zipFileName := strings.Split(desiredVersion.Url, "/")[len(strings.Split(desiredVersion.Url, "/"))-1]
+	zipPath := filepath.Join(versionsPath, zipFileName)
 
 	// check if zip already exists
-	if _, err := os.Stat(homeDir + "/.pvm/versions/" + zipFileName); err == nil {
+	if _, err := os.Stat(zipPath); err == nil {
 		theme.Error(fmt.Sprintf("PHP %s already exists", desiredVersion))
 		return
 	}
 
-	// Create the file
-	out, err := os.Create(homeDir + "/.pvm/versions/" + zipFileName)
-	if err != nil {
-		log.Fatalln(err)
+	// Get the data
+	if _, err := downloadFile(zipUrl, zipPath); err != nil {
+		log.Fatalf("Error while downloading PHP from %v: %v!", zipUrl, err)
 	}
-
-	// Write the body to file
-	_, err = io.Copy(out, downloadResponse.Body)
-
-	if err != nil {
-		out.Close()
-		log.Fatalln(err)
-	}
-
-	// Close the file
-	out.Close()
 
 	// extract the zip file to a folder
+	phpFolder := strings.Replace(zipFileName, ".zip", "", -1)
+	phpPath := filepath.Join(versionsPath, phpFolder)
 	theme.Info("Unzipping")
-	Unzip(homeDir+"/.pvm/versions/"+zipFileName, homeDir+"/.pvm/versions/"+strings.Replace(zipFileName, ".zip", "", -1))
+	Unzip(zipPath, phpPath)
 
 	// remove the zip file
 	theme.Info("Cleaning up")
-	err = os.Remove(homeDir + "/.pvm/versions/" + zipFileName)
+	err = os.Remove(zipPath)
 	if err != nil {
 		log.Fatalln(err)
+	}
+
+	// install composer
+	composerPath := filepath.Join(phpPath, "composer.phar")
+	composerUrl := "https://getcomposer.org/download/latest-stable/composer.phar"
+	if desiredVersion.LessThan(common.Version{Major: 7, Minor: 2}) {
+		composerUrl = "https://getcomposer.org/download/latest-2.2.x/composer.phar"
+	}
+
+	if _, err := downloadFile(composerUrl, composerPath); err != nil {
+		log.Fatalf("Error while downloading Composer from %v: %v!", composerUrl, err)
 	}
 
 	theme.Success(fmt.Sprintf("Finished installing PHP %s", desiredVersion))
@@ -315,4 +312,31 @@ func FindLatestMinor(versions []common.Version, major int, threadSafe bool) comm
 	}
 
 	return latestMinor
+}
+
+func downloadFile(fileUrl string, filePath string) (bool, error) {
+	downloadResponse, err := http.Get(fileUrl)
+	if err != nil {
+		return false, err
+	}
+
+	defer downloadResponse.Body.Close()
+
+	// Create the file
+	out, err := os.Create(filePath)
+	if err != nil {
+		return false, err
+	}
+
+	// Write the body to file
+	_, err = io.Copy(out, downloadResponse.Body)
+
+	if err != nil {
+		out.Close()
+		return false, err
+	}
+
+	// Close the file
+	out.Close()
+	return true, nil
 }

--- a/commands/use.go
+++ b/commands/use.go
@@ -108,9 +108,22 @@ func Use(args []string) {
 		os.Remove(shPathCGI)
 	}
 
+	// remove old php bat script
+	batPathComposer := filepath.Join(binPath, "composer.bat")
+	if _, err := os.Stat(batPathComposer); err == nil {
+		os.Remove(batPathComposer)
+	}
+
+	// remove the old php sh script
+	shPathComposer := filepath.Join(binPath, "composer")
+	if _, err := os.Stat(shPathComposer); err == nil {
+		os.Remove(shPathComposer)
+	}
+
 	versionFolderPath := filepath.Join(homeDir, ".pvm", "versions", selectedVersion.folder.Name())
 	versionPath := filepath.Join(versionFolderPath, "php.exe")
 	versionPathCGI := filepath.Join(versionFolderPath, "php-cgi.exe")
+	composerPath := filepath.Join(versionFolderPath, "composer", "composer.phar")
 
 	// create bat script for php
 	batCommand := "@echo off \n"
@@ -153,6 +166,31 @@ func Use(args []string) {
 	shCommandCGI = shCommandCGI + "\"$filepath\" \"$@\""
 
 	err = os.WriteFile(shPathCGI, []byte(shCommandCGI), 0755)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// create bat script for composer
+	batCommandComposer := "@echo off \n"
+	batCommandComposer = batCommandComposer + "set filepath=\"" + versionPath + "\"\n"
+	batCommandComposer = batCommandComposer + "set composerpath=\"" + composerPath + "\"\n"
+	batCommandComposer = batCommandComposer + "set arguments=%*\n"
+	batCommandComposer = batCommandComposer + "%filepath% %composerpath% %arguments%\n"
+
+	err = os.WriteFile(batPath, []byte(batCommandComposer), 0755)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// create sh script for php
+	shCommandComposer := "#!/bin/bash\n"
+	shCommandComposer = shCommandComposer + "filepath=\"" + versionPath + "\"\n"
+	shCommandComposer = shCommandComposer + "composerpath=\"" + composerPath + "\"\n"
+	shCommandComposer = shCommandComposer + "\"$filepath\" \"$composerpath\" \"$@\""
+
+	err = os.WriteFile(shPath, []byte(shCommandComposer), 0755)
 
 	if err != nil {
 		log.Fatalln(err)

--- a/commands/use.go
+++ b/commands/use.go
@@ -108,13 +108,13 @@ func Use(args []string) {
 		os.Remove(shPathCGI)
 	}
 
-	// remove old php bat script
+	// remove old composer bat script
 	batPathComposer := filepath.Join(binPath, "composer.bat")
 	if _, err := os.Stat(batPathComposer); err == nil {
 		os.Remove(batPathComposer)
 	}
 
-	// remove the old php sh script
+	// remove the old composer sh script
 	shPathComposer := filepath.Join(binPath, "composer")
 	if _, err := os.Stat(shPathComposer); err == nil {
 		os.Remove(shPathComposer)
@@ -178,7 +178,7 @@ func Use(args []string) {
 	batCommandComposer = batCommandComposer + "set arguments=%*\n"
 	batCommandComposer = batCommandComposer + "%filepath% %composerpath% %arguments%\n"
 
-	err = os.WriteFile(batPath, []byte(batCommandComposer), 0755)
+	err = os.WriteFile(batPathComposer, []byte(batCommandComposer), 0755)
 
 	if err != nil {
 		log.Fatalln(err)
@@ -190,7 +190,7 @@ func Use(args []string) {
 	shCommandComposer = shCommandComposer + "composerpath=\"" + composerPath + "\"\n"
 	shCommandComposer = shCommandComposer + "\"$filepath\" \"$composerpath\" \"$@\""
 
-	err = os.WriteFile(shPath, []byte(shCommandComposer), 0755)
+	err = os.WriteFile(shPathComposer, []byte(shCommandComposer), 0755)
 
 	if err != nil {
 		log.Fatalln(err)

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -52,3 +52,60 @@ func GetVersion(text string, safe bool, url string) Version {
 		Url:        url,
 	}
 }
+
+func (v Version) Compare(o Version) int {
+	if v.Major == -1 || o.Major == -1 {
+		return 0
+	}
+	if v.Major != o.Major {
+		if v.Major < o.Major {
+			return -1
+		}
+		return 1
+	}
+
+	if v.Minor == -1 || o.Minor == -1 {
+		return 0
+	}
+	if v.Minor != o.Minor {
+		if v.Minor < o.Minor {
+			return -1
+		}
+		return 1
+	}
+
+	if v.Patch == -1 || o.Patch == -1 {
+		return 0
+	}
+	if v.Patch != o.Patch {
+		if v.Patch < o.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func (v Version) LessThan(other Version) bool {
+	return v.Compare(other) == -1
+}
+
+func (v Version) LessThanOrEqual(other Version) bool {
+	return v.Compare(other) == -1 || v.Compare(other) == 0
+}
+
+func (v Version) GreaterThan(other Version) bool {
+	return v.Compare(other) == 1
+}
+
+func (v Version) GreaterThanOrEqual(other Version) bool {
+	return v.Compare(other) == 1 || v.Compare(other) == 0
+}
+
+func (v Version) Equal(other Version) bool {
+	return v.Compare(other) == 0
+}
+
+func (v Version) Same(other Version) bool {
+	return v.Compare(other) == 0 && v.ThreadSafe == other.ThreadSafe
+}

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Version_Compare(t *testing.T) {
+	v1 := Version{Major: 1, Minor: 2, Patch: 3, ThreadSafe: false}
+	v2 := Version{Major: 1, Minor: 2, Patch: 4}
+	v3 := Version{Major: 1, Minor: 2, Patch: 3, ThreadSafe: true}
+
+	assert.Equal(t, v1.LessThan(v2), true)
+	assert.Equal(t, v1.LessThanOrEqual(v2), true)
+	assert.Equal(t, v1.LessThanOrEqual(v3), true)
+	assert.Equal(t, v1.GreaterThan(v2), false)
+	assert.Equal(t, v1.GreaterThanOrEqual(v2), false)
+	assert.Equal(t, v1.GreaterThanOrEqual(v3), true)
+	assert.Equal(t, v1.Equal(v2), false)
+	assert.Equal(t, v1.Equal(v3), true)
+	assert.Equal(t, v1.Same(v3), false)
+
+	// testing versions with "nulled" (-1) values
+
+	v4 := Version{Major: 1, Minor: 2, Patch: -1}
+	v5 := Version{Major: 1, Minor: 2, Patch: 3}
+
+	assert.Equal(t, v4.LessThan(v5), false)
+	assert.Equal(t, v4.LessThanOrEqual(v5), true)
+	assert.Equal(t, v4.GreaterThan(v5), false)
+	assert.Equal(t, v4.GreaterThanOrEqual(v5), true)
+	assert.Equal(t, v4.Equal(v5), true)
+
+	v6 := Version{Major: 1, Minor: -1}
+	v7 := Version{Major: 1, Minor: 2}
+
+	assert.Equal(t, v6.LessThan(v7), false)
+	assert.Equal(t, v6.LessThanOrEqual(v7), true)
+	assert.Equal(t, v6.GreaterThan(v7), false)
+	assert.Equal(t, v6.GreaterThanOrEqual(v7), true)
+	assert.Equal(t, v6.Equal(v7), true)
+}


### PR DESCRIPTION
This PR downloads composer.phar from composer official website inside the php version folder.
A dedicated batch and bash script files are created in the same way of the others.

Result: composer can be invoked from command line by typing `composer`.


I had to introduce a Version struct Compare method because older versions of PHP (<7.2) requires a specific version of composer.phar.